### PR TITLE
Integrate Pylint CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,6 +36,10 @@ jobs:
         conda install conda-forge::dftbplus
         python -m pip install --upgrade pip
         pip install . 
+    - name: Lint with Pylint
+      run: |
+        pip install '.[lint]'
+        python -m pylint ThermoScreening
     - name: Test with pytest
       run: |
         pip install '.[test]'

--- a/ThermoScreening/__init__.py
+++ b/ThermoScreening/__init__.py
@@ -24,9 +24,10 @@ if logging_env_var and logging_env_var not in logging.getLevelNamesMapping():
         f"levels are: {logging.getLevelNamesMapping()}"
     )
 
-if 'execution_start_time' not in vars(
-) and 'execution_start_time' not in globals():
-    execution_start_time = time.strftime('%Y-%m-%d_%H-%M-%S', time.localtime())
+execution_start_time = globals().get(
+    "execution_start_time",
+    time.strftime("%Y-%m-%d_%H-%M-%S", time.localtime()),
+)
 
 logging.setLoggerClass(CustomLogger)
 logging.basicConfig(level=os.getenv("THERMOSCREENING_LOGGING_LEVEL", "INFO"))
@@ -34,7 +35,7 @@ package_logger = logging.getLogger(__name__)
 
 log_file_env_var = os.getenv("THERMOSCREENING_LOG_FILE")
 
-if log_file_env_var and logging_env_var.lower() != "off":
+if log_file_env_var and (logging_env_var or "").lower() != "off":
     config.use_log_file = True
 
     if log_file_env_var.lower() != "on" and len(log_file_env_var) > 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ test = [
     "coverage",
     "pytest-cov"
 ]
+lint = [
+    "pylint >= 4.0, < 5",
+]
 docs = [
     "sphinx",
 ]
@@ -47,3 +50,11 @@ version_file = "ThermoScreening/__version__.py"
 
 [project.scripts]
 thermo = "ThermoScreening.cli.thermo:main"
+
+[tool.pylint.main]
+fail-under = 7.0
+persistent = false
+py-version = "3.10"
+
+[tool.pylint.reports]
+score = true

--- a/tests/test_package_init.py
+++ b/tests/test_package_init.py
@@ -1,0 +1,21 @@
+import importlib
+
+import ThermoScreening
+import ThermoScreening.config as config
+
+
+def test_log_file_env_works_without_logging_level(monkeypatch):
+    monkeypatch.setenv("THERMOSCREENING_LOG_FILE", "on")
+    monkeypatch.delenv("THERMOSCREENING_LOGGING_LEVEL", raising=False)
+    monkeypatch.setattr(config, "use_log_file", False)
+    monkeypatch.setattr(config, "log_file_name", None)
+
+    importlib.reload(ThermoScreening)
+
+    assert config.use_log_file is True
+    assert config.log_file_name.startswith("ThermoScreening_")
+
+    monkeypatch.delenv("THERMOSCREENING_LOG_FILE", raising=False)
+    monkeypatch.setattr(config, "use_log_file", False)
+    monkeypatch.setattr(config, "log_file_name", None)
+    importlib.reload(ThermoScreening)


### PR DESCRIPTION
## Summary
- add a Pylint optional dependency and project threshold
- run Pylint in CI before tests
- simplify startup log timestamp and log-file env handling

## Validation
- python -m pylint ThermoScreening
- python -m pytest -q

Closes #11