### PR TITLE
Enable dynamic type checking

### DIFF
--- a/ThermoScreening/__init__.py
+++ b/ThermoScreening/__init__.py
@@ -4,9 +4,15 @@ import time
 
 from pathlib import Path
 
-import ThermoScreening.config as config  # pylint: disable=consider-using-from-import
+from beartype import BeartypeConf
+from beartype.claw import beartype_this_package
 
-from ThermoScreening.utils.custom_logging import CustomLogger
+beartype_this_package(conf=BeartypeConf(is_pep484_tower=True))
+
+# The type-checking import hook must be installed before package submodules load.
+import ThermoScreening.config as config  # pylint: disable=consider-using-from-import,wrong-import-position
+
+from ThermoScreening.utils.custom_logging import CustomLogger  # pylint: disable=wrong-import-position
 
 BASE_PATH = os.path.dirname(os.path.abspath(__file__)) + "/"
 __base_path__ = Path(__file__).parent

--- a/ThermoScreening/thermo/cell.py
+++ b/ThermoScreening/thermo/cell.py
@@ -175,13 +175,14 @@ class Cell:
         if self._cell_parameters is None:
             self._cell_parameters = cell_parameters_calc(cell_vectors)
         else:
+            cell_args = [float(value) for value in self._cell_parameters]
             self._cell_vectors = cell(
-                self._cell_parameters[0],
-                self._cell_parameters[1],
-                self._cell_parameters[2],
-                self._cell_parameters[3],
-                self._cell_parameters[4],
-                self._cell_parameters[5],
+                cell_args[0],
+                cell_args[1],
+                cell_args[2],
+                cell_args[3],
+                cell_args[4],
+                cell_args[5],
             )
 
         if self._volume is None:

--- a/ThermoScreening/thermo/system.py
+++ b/ThermoScreening/thermo/system.py
@@ -296,7 +296,7 @@ def rotational_group_calc(atoms: List[Atom]) -> str:
     return symb
 
 
-def center_of_mass(atoms: List[Atom], mass: float) -> None:
+def center_of_mass(atoms: List[Atom], mass: float) -> np.ndarray:
     """
     Calculates the center of mass of the system.
 
@@ -518,8 +518,8 @@ class System:
         atoms: List[Atom] | None = None,
         charge: float | None = None,
         periodicity: bool | None = None,
-        pbc: List[bool] | None = None,
-        cell: Cell | None = None,
+        pbc: List[bool] | bool | None = None,
+        cell: Cell | np.ndarray | None = None,
         solvation: bool | None = None,
         solvent: str | None = None,
         electronic_energy: float | None = None,
@@ -810,7 +810,7 @@ class System:
         return self._periodicity
 
     @property
-    def pbc(self) -> List[bool]:
+    def pbc(self) -> List[bool] | bool:
         """
         The periodic boundary conditions of the system.
 
@@ -823,7 +823,7 @@ class System:
         return self._pbc
 
     @property
-    def cell(self) -> np.ndarray:
+    def cell(self) -> Cell | np.ndarray | None:
         """
         The cell of the system.
 
@@ -835,7 +835,7 @@ class System:
         return self._cell
 
     @property
-    def solvation(self) -> str:
+    def solvation(self) -> bool:
         """
         The solvation of the system.
 

--- a/ThermoScreening/thermo/thermo.py
+++ b/ThermoScreening/thermo/thermo.py
@@ -10,6 +10,15 @@ from ThermoScreening import __package_name__
 from .system import System
 
 
+def _real_scalar(value) -> float:
+    value = np.real_if_close(value)
+    if np.iscomplexobj(value):
+        if not np.allclose(np.imag(value), 0.0):
+            raise TypeError("Expected a real scalar value.")
+        value = np.real(value)
+    return float(value)
+
+
 class Thermo:
     """
     A class for calculating the thermochemistral properties e.g. Gibbs free energy,
@@ -723,11 +732,11 @@ class Thermo:
         """
 
         if unit == "H":
-            return self._total_energy_Hartree_per_mol
+            return _real_scalar(self._total_energy_Hartree_per_mol)
         elif unit == "kcal":
-            return self._total_energy_kcal
+            return _real_scalar(self._total_energy_kcal)
         elif unit == "cal":
-            return self._total_energy
+            return _real_scalar(self._total_energy)
         else:
             self.logger.error(
                 "The unit is not supported.",
@@ -755,11 +764,11 @@ class Thermo:
         """
 
         if unit == "H":
-            return self._total_enthalpy_Hartree_per_mol
+            return _real_scalar(self._total_enthalpy_Hartree_per_mol)
         elif unit == "kcal":
-            return self._total_enthalpy_kcal
+            return _real_scalar(self._total_enthalpy_kcal)
         elif unit == "cal":
-            return self._total_enthalpy
+            return _real_scalar(self._total_enthalpy)
         else:
             self.logger.error(
                 "The unit is not supported.",
@@ -787,9 +796,9 @@ class Thermo:
         """
 
         if unit == "H/T":
-            return self._total_entropy_Hartree_per_mol
+            return _real_scalar(self._total_entropy_Hartree_per_mol)
         elif unit == "cal/(mol*K)":
-            return self._total_entropy
+            return _real_scalar(self._total_entropy)
         else:
             self.logger.error(
                 "The unit is not supported.",
@@ -817,11 +826,11 @@ class Thermo:
         """
 
         if unit == "H":
-            return self._total_gibbs_free_energy_Hartree_per_mol
+            return _real_scalar(self._total_gibbs_free_energy_Hartree_per_mol)
         elif unit == "kcal":
-            return self._total_gibbs_free_energy_kcal
+            return _real_scalar(self._total_gibbs_free_energy_kcal)
         elif unit == "cal":
-            return self._total_gibbs_free_energy
+            return _real_scalar(self._total_gibbs_free_energy)
         else:
             self.logger.error(
                 "The unit is not supported.",
@@ -849,9 +858,9 @@ class Thermo:
         """
 
         if unit == "cal/(mol*K)":
-            return self._total_heatcapacity
+            return _real_scalar(self._total_heatcapacity)
         elif unit == "H/T":
-            return (
+            return _real_scalar(
                 self._total_heatcapacity
                 * PhysicalConstants["cal"]
                 / PhysicalConstants["H"]
@@ -873,7 +882,7 @@ class Thermo:
             The sum of the electronic energy and the zero point energy correction in Hartree per particle.
         """
 
-        return self._EeZPE
+        return _real_scalar(self._EeZPE)
 
     def total_EeEtot(self) -> float:
         """
@@ -885,7 +894,7 @@ class Thermo:
             The sum of the electronic energy and the total energy in Hartree per particle.
         """
 
-        return self._EeEtot
+        return _real_scalar(self._EeEtot)
 
     def total_EeHtot(self) -> float:
         """
@@ -897,7 +906,7 @@ class Thermo:
             The sum of the electronic energy and the total enthalpy in Hartree per particle.
         """
 
-        return self._EeHtot
+        return _real_scalar(self._EeHtot)
 
     def total_EeGtot(self) -> float:
         """
@@ -909,7 +918,7 @@ class Thermo:
             The sum of the electronic energy and the total Gibbs free energy in Hartree per particle.
         """
 
-        return self._EeGtot
+        return _real_scalar(self._EeGtot)
 
     def electronic_energy(self) -> float:
         """
@@ -921,4 +930,4 @@ class Thermo:
             The electronic energy of the system in Hartree per particle.
         """
 
-        return self._system.electronic_energy
+        return _real_scalar(self._system.electronic_energy)

--- a/ThermoScreening/utils/custom_logging.py
+++ b/ThermoScreening/utils/custom_logging.py
@@ -80,7 +80,7 @@ class CustomLogger(logging.Logger):
              level: Any,
              msg: Any,
              args: Any,
-             exception: Exception | None = None,
+             exception: type[Exception] | None = None,
              **kwargs
              ) -> None:
         """
@@ -187,7 +187,7 @@ class CustomLogger(logging.Logger):
         self,
         msg: Any,
         *args,
-        exception: Exception | None = None,
+        exception: type[Exception] | None = None,
         **kwargs
     ) -> None:
         """
@@ -237,7 +237,7 @@ class CustomLogger(logging.Logger):
         self,
         msg: Any,
         *args,
-        exception: Exception | None = None,
+        exception: type[Exception] | None = None,
         **kwargs
     ) -> None:
         """

--- a/ThermoScreening/utils/header.py
+++ b/ThermoScreening/utils/header.py
@@ -1,9 +1,11 @@
 import sys
 
+from beartype.typing import Any
+
 from ThermoScreening.version import __version__
 
 
-def print_header(file: str | None = None) -> None:
+def print_header(file: Any = None) -> None:
     """
     A function to print the header
     

--- a/tests/thermo/test_api.py
+++ b/tests/thermo/test_api.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 from pathlib import Path
 from unittest.mock import patch, mock_open
+from beartype.roar import BeartypeCallHintParamViolation
 from ThermoScreening.calculator.dftbplus import dftb_3ob_parameters
 from ThermoScreening.thermo.api import (
     dftbplus_thermo,
@@ -64,6 +65,10 @@ class TestApi(unittest.TestCase):
         assert str(e.value) == "The engine is not supported."
         
         assert unit_frequency(engine="dftb+") == "cm^-1"
+
+    def test_public_api_rejects_wrong_argument_type(self):
+        with pytest.raises(BeartypeCallHintParamViolation):
+            unit_length(engine=object())
             
    
     @patch(

--- a/tests/thermo/test_thermo.py
+++ b/tests/thermo/test_thermo.py
@@ -7,8 +7,85 @@ import numpy as np
 from ThermoScreening.thermo.system import System
 from ThermoScreening.thermo.atoms import Atom
 from ThermoScreening.thermo.cell import Cell
-from ThermoScreening.thermo.thermo import Thermo
+from ThermoScreening.thermo.thermo import Thermo, _real_scalar
+from ThermoScreening.exceptions import TSValueError
+from ThermoScreening.utils.physicalConstants import PhysicalConstants
 
+
+def _thermo_with_scalar_totals():
+    thermo = object.__new__(Thermo)
+    thermo._total_energy_Hartree_per_mol = np.complex128(1.0 + 0.0j)
+    thermo._total_energy_kcal = np.complex128(2.0 + 0.0j)
+    thermo._total_energy = np.complex128(3.0 + 0.0j)
+    thermo._total_enthalpy_Hartree_per_mol = np.complex128(4.0 + 0.0j)
+    thermo._total_enthalpy_kcal = np.complex128(5.0 + 0.0j)
+    thermo._total_enthalpy = np.complex128(6.0 + 0.0j)
+    thermo._total_entropy_Hartree_per_mol = np.complex128(7.0 + 0.0j)
+    thermo._total_entropy = np.complex128(8.0 + 0.0j)
+    thermo._total_gibbs_free_energy_Hartree_per_mol = np.complex128(9.0 + 0.0j)
+    thermo._total_gibbs_free_energy_kcal = np.complex128(10.0 + 0.0j)
+    thermo._total_gibbs_free_energy = np.complex128(11.0 + 0.0j)
+    thermo._total_heatcapacity = np.complex128(12.0 + 0.0j)
+    thermo._EeZPE = np.complex128(13.0 + 0.0j)
+    thermo._EeEtot = np.complex128(14.0 + 0.0j)
+    thermo._EeHtot = np.complex128(15.0 + 0.0j)
+    thermo._EeGtot = np.complex128(16.0 + 0.0j)
+    thermo._system = type("SystemStub", (), {
+        "electronic_energy": np.complex128(17.0 + 0.0j)
+    })()
+    return thermo
+
+
+def test_real_scalar_accepts_zero_imaginary_complex():
+    assert _real_scalar(np.complex128(1.25 + 0.0j)) == 1.25
+    assert _real_scalar(np.complex128(1.25 + 1e-12j)) == pytest.approx(1.25)
+
+
+def test_real_scalar_rejects_nonzero_imaginary_complex():
+    with pytest.raises(TypeError):
+        _real_scalar(np.complex128(1.25 + 0.5j))
+
+
+def test_scalar_total_accessors_return_real_floats_for_all_units():
+    thermo = _thermo_with_scalar_totals()
+
+    assert thermo.total_energy("H") == 1.0
+    assert thermo.total_energy("kcal") == 2.0
+    assert thermo.total_energy("cal") == 3.0
+    assert thermo.total_enthalpy("H") == 4.0
+    assert thermo.total_enthalpy("kcal") == 5.0
+    assert thermo.total_enthalpy("cal") == 6.0
+    assert thermo.total_entropy("H/T") == 7.0
+    assert thermo.total_entropy("cal/(mol*K)") == 8.0
+    assert thermo.total_gibbs_free_energy("H") == 9.0
+    assert thermo.total_gibbs_free_energy("kcal") == 10.0
+    assert thermo.total_gibbs_free_energy("cal") == 11.0
+    assert thermo.total_heat_capacity("cal/(mol*K)") == 12.0
+    assert thermo.total_heat_capacity("H/T") == pytest.approx(
+        12.0 * PhysicalConstants["cal"] / PhysicalConstants["H"] / PhysicalConstants["N_A"]
+    )
+    assert thermo.total_EeZPE() == 13.0
+    assert thermo.total_EeEtot() == 14.0
+    assert thermo.total_EeHtot() == 15.0
+    assert thermo.total_EeGtot() == 16.0
+    assert thermo.electronic_energy() == 17.0
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "total_energy",
+        "total_enthalpy",
+        "total_entropy",
+        "total_gibbs_free_energy",
+        "total_heat_capacity",
+    ],
+)
+def test_scalar_total_accessors_reject_unknown_units(method_name):
+    thermo = _thermo_with_scalar_totals()
+
+    with pytest.raises(TSValueError):
+        getattr(thermo, method_name)("unknown")
 
 
 class TestThermo(unittest.TestCase):


### PR DESCRIPTION
## Summary
- enable package-wide beartype runtime checks
- correct annotations exposed by runtime checking
- add a regression test for public API type validation

## Validation
- python -m pylint ThermoScreening
- python -m pytest -q

Closes #19