### PR TITLE
Use PQAnalysis for gen parsing

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10 with conda
+    - name: Set up Python 3.12 with conda
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Add conda to system path
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -32,8 +32,7 @@ jobs:
         echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       run: |
-        conda install conda-forge::gsl
-        conda install conda-forge::dftbplus
+        conda install -y -c conda-forge python=3.12 gsl dftbplus
         python -m pip install --upgrade pip
         pip install . 
     - name: Test with pytest

--- a/ThermoScreening/thermo/api.py
+++ b/ThermoScreening/thermo/api.py
@@ -1,6 +1,7 @@
 import logging
 
 import numpy as np
+from PQAnalysis.io import read_gen_file
 
 from ThermoScreening.exceptions import TSNotImplementedError, TSValueError
 from ThermoScreening.utils.custom_logging import setup_logger
@@ -87,40 +88,19 @@ def read_gen(coord_file: str):
     List
         number of atoms, chemical symbols of atoms, coordinates of atoms, cell vector
     """
-    with open(coord_file, "r") as f:
-        line = f.readline().strip()
-        line = line.split()
-        data_N = int(line[0])
-        system = str(line[1])
-        if system == "S":
-            pbc = True
-        else:
-            pbc = False
-        atomic_species = f.readline().strip().split()
+    system = read_gen_file(coord_file)
 
-        data_atoms = np.empty(data_N, dtype=object)
-        data_xyz = np.zeros((data_N, 3), dtype=float)
-        for i in range(data_N):
-            line = f.readline().strip().split()
-            symbol_number = int(line[1])
-            data_atoms[i] = atomic_species[symbol_number - 1]
-            data_xyz[i, 0] = float(line[2])
-            data_xyz[i, 1] = float(line[3])
-            data_xyz[i, 2] = float(line[4])
-        if pbc:
-            f.readline()
-            line = f.readline().split()
-            line2 = f.readline().split()
-            line3 = f.readline().split()
-            cell_vector = np.array(
-                [
-                    [float(line[0]), float(line[1]), float(line[2])],
-                    [float(line2[0]), float(line2[1]), float(line2[2])],
-                    [float(line3[0]), float(line3[1]), float(line3[2])],
-                ]
-            )
-        else:
-            cell_vector = None
+    data_N = system.n_atoms
+    data_atoms = np.array([atom.name for atom in system.atoms], dtype=object)
+    data_xyz = np.asarray(system.pos, dtype=float)
+
+    if system.cell.is_vacuum:
+        cell_vector = None
+        pbc = False
+    else:
+        cell_vector = np.asarray(system.cell.box_matrix, dtype=float)
+        cell_vector[np.isclose(cell_vector, 0.0, atol=1e-12)] = 0.0
+        pbc = True
 
     return [data_N, data_atoms, data_xyz, cell_vector, pbc]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
   { name="Josef M. Gallmetzer", email="gallmetzer.josef@gmail.com" },
 ]
 description = "A Python package for screening molecules for their thermochemical properties."
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 readme = "README.md"
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -27,6 +27,7 @@ dependencies = [
     "beartype",
     "ase",
     "rdkit",
+    "PQAnalysis >= 1.2.5",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "beartype",
     "ase",
     "rdkit",
-    "PQAnalysis @ git+https://github.com/MolarVerse/PQAnalysis.git@0a951591732a6c337a536ecb5512fea353cf3344",
+    "PQAnalysis >= 1.3.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "beartype",
     "ase",
     "rdkit",
-    "PQAnalysis >= 1.2.5",
+    "PQAnalysis @ git+https://github.com/MolarVerse/PQAnalysis.git@0a951591732a6c337a536ecb5512fea353cf3344",
 ]
 
 [project.optional-dependencies]

--- a/tests/thermo/test_api.py
+++ b/tests/thermo/test_api.py
@@ -3,6 +3,7 @@ import pytest
 import unittest
 import numpy as np
 import pytest
+from types import SimpleNamespace
 from pathlib import Path
 from unittest.mock import patch, mock_open
 from ThermoScreening.calculator.dftbplus import dftb_3ob_parameters
@@ -217,19 +218,18 @@ class TestApi(unittest.TestCase):
         np.testing.assert_allclose(coord_data[3], cell)
         assert coord_data[4] is True
 
-    @patch(
-        "builtins.open",
-        new_callable=mock_open,
-        read_data=(
-            "2 C\n"
-            "Cl Na\n"
-            "1 1 0.0 0.0 0.0\n"
-            "2 2 1.0 2.0 3.0\n"
-        ),
-    )
-    def test_read_gen_keeps_multichar_symbols(self, mock_open):
+    @patch("ThermoScreening.thermo.api.read_gen_file")
+    def test_read_gen_uses_pqanalysis(self, read_gen_file_mock):
+        read_gen_file_mock.return_value = SimpleNamespace(
+            n_atoms=2,
+            atoms=[SimpleNamespace(name="Cl"), SimpleNamespace(name="Na")],
+            pos=np.array([[0.0, 0.0, 0.0], [1.0, 2.0, 3.0]]),
+            cell=SimpleNamespace(is_vacuum=True),
+        )
+
         data_N, data_atoms, data_xyz, cell, pbc = read_gen("test.gen")
 
+        read_gen_file_mock.assert_called_once_with("test.gen")
         assert data_N == 2
         np.testing.assert_array_equal(data_atoms, np.array(["Cl", "Na"], dtype=object))
         np.testing.assert_allclose(data_xyz, np.array([[0.0, 0.0, 0.0], [1.0, 2.0, 3.0]]))


### PR DESCRIPTION
## Summary
- Delegate `.gen` parsing to `PQAnalysis.io.read_gen_file`.
- Preserve ThermoScreening's existing `read_gen()` return format.
- Add PQAnalysis 1.3.0+ as a runtime dependency and align CI with Python 3.12.

## Validation
- `python -m pytest tests/thermo/test_api.py -q`
- isolated install of `PQAnalysis==1.3.0` reads `geo_opt.gen`
- `python -m pip install --dry-run .`
- `python -m pytest --cov=ThermoScreening --cov-report=term-missing -q`

Refs #10