### PR TITLE
Stop periodic systems from crashing System construction

### DIFF
--- a/ThermoScreening/thermo/system.py
+++ b/ThermoScreening/thermo/system.py
@@ -655,12 +655,15 @@ class System:
         self._center_of_mass = center_of_mass(atoms, self._mass)
         self._symmetry_number = rotational_symmetry_number(atoms)
         self._rotational_group = rotational_group_calc(atoms)
-        if self._cell is None:
-            self._spacegroup_number = None
-            self._spacegroup = None
-        else:
+        if isinstance(self._cell, Cell):
             self._spacegroup_number = spacegroup_number(atoms, self._cell)
             self._spacegroup = spacegroup(atoms, self._cell)
+        else:
+            # Periodic input arrives as a raw cell array (from read_xyz/read_gen)
+            # and the spacegroup is unused by the gas-phase RRHO calculation, so
+            # degrade to None instead of feeding a non-Cell into spacegroup().
+            self._spacegroup_number = None
+            self._spacegroup = None
         self._imaginary_frequencies = imaginary_frequencies(vibrational_frequencies)
         self._has_imaginary_frequencies = check_imaginary_frequencies(
             self._imaginary_frequencies
@@ -823,17 +826,17 @@ class System:
         return self._rotational_group
 
     @property
-    def spacegroup_number(self) -> None | str:
+    def spacegroup_number(self) -> None | int:
         """
-        The spacegroup of the system.
+        The spacegroup number of the system.
 
         Returns
         -------
-        str, None
-            The spacegroup of the system.
+        int, None
+            The spacegroup number of the system.
         """
 
-        return self._spacegroup
+        return self._spacegroup_number
 
     @property
     def spacegroup(self) -> None | str:

--- a/tests/thermo/test_system.py
+++ b/tests/thermo/test_system.py
@@ -532,6 +532,43 @@ class TestSystem(unittest.TestCase):
 
         assert system.periodicity is False
 
+    def test_system_accepts_periodic_ndarray_cell(self):
+        # read_xyz/read_gen hand back a raw ndarray cell for periodic input;
+        # System must construct instead of raising on the spacegroup hint, and
+        # degrade the (unused) spacegroup to None.
+        cell = np.array([[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]])
+
+        system = System(
+            self.atoms,
+            periodicity=True,
+            cell=cell,
+            solvation=None,
+            solvent=None,
+            charge=0,
+            electronic_energy=-33.6052447996,
+            vibrational_frequencies=np.array([-1, -2, 0.1, 1, 2, 3, 4, 5, 6]),
+        )
+
+        assert system.spacegroup_number is None
+        assert system.spacegroup is None
+
+    def test_spacegroup_properties_map_to_their_attributes(self):
+        system = System(
+            self.atoms,
+            periodicity=False,
+            cell=None,
+            solvation=None,
+            solvent=None,
+            charge=0,
+            electronic_energy=-33.6052447996,
+            vibrational_frequencies=np.array([-1, -2, 0.1, 1, 2, 3, 4, 5, 6]),
+        )
+        system._spacegroup_number = 1
+        system._spacegroup = "P1"
+
+        assert system.spacegroup_number == 1
+        assert system.spacegroup == "P1"
+
         np.testing.assert_array_equal(system.center_of_mass, [1, 0, 0])
 
         assert system.pbc == [False, False, False]


### PR DESCRIPTION
Closes #48.

`System.__init__` accepts `cell: Cell | np.ndarray | None` but passed the value straight to `spacegroup_number`/`spacegroup`, which are beartype-hinted `cell: Cell`. Since `read_xyz`/`read_gen` return raw ndarrays for periodic input (and `beartype_this_package` is active), every non-vacuum system aborted construction with `BeartypeCallHintParamViolation` — the package was effectively vacuum-only, and the repo's own periodic fixture `tests/data/thermo/geo_opt.gen` could not be run.

## Fix
- Compute the spacegroup only when the cell is an actual `Cell`; otherwise degrade to `spacegroup=None`. The cell/spacegroup is unused by the gas-phase RRHO calculation, so periodic input now constructs cleanly instead of crashing.
- Fix the `spacegroup_number` property, which returned `_spacegroup` (the symbol string) instead of `_spacegroup_number`.

## Tests
- A periodic System built from a raw ndarray cell now constructs and reports `spacegroup_number`/`spacegroup` as `None` (previously raised).
- A property test pins `spacegroup_number`/`spacegroup` to their respective attributes.

141 passed, 0 skipped (suite run with the DFTB+ binaries enabled); pylint 7.94/10.