### PR TITLE
Classify linearity from COM-relocated inertia tensor

### DIFF
--- a/ThermoScreening/thermo/system.py
+++ b/ThermoScreening/thermo/system.py
@@ -108,17 +108,25 @@ def linearity(atoms: List[Atom]) -> bool:
         )
     elif len(atoms) == 2:
         return True
-    else:
-        # compute inertia tensor and eigenvalues
-        inertia_tensor = np.zeros((3, 3))
-        for atom in atoms:
-            inertia_tensor += atom.mass * np.outer(atom.position, atom.position)
-        eigenvalues = np.linalg.eigvalsh(inertia_tensor)
-        # check if the smallest eigenvalue is zero
-        if eigenvalues[0] == 0:
-            return True
-        else:
-            return False
+
+    masses = np.array([atom.mass for atom in atoms], dtype=float)
+    positions = np.array([_real_position(atom.position) for atom in atoms])
+    # relocate to the center of mass so linearity is translation-invariant
+    positions = positions - np.average(positions, axis=0, weights=masses)
+
+    x, y, z = positions[:, 0], positions[:, 1], positions[:, 2]
+    inertia_tensor = np.zeros((3, 3))
+    inertia_tensor[0, 0] = np.sum(masses * (y**2 + z**2))
+    inertia_tensor[1, 1] = np.sum(masses * (x**2 + z**2))
+    inertia_tensor[2, 2] = np.sum(masses * (x**2 + y**2))
+    inertia_tensor[0, 1] = inertia_tensor[1, 0] = -np.sum(masses * x * y)
+    inertia_tensor[0, 2] = inertia_tensor[2, 0] = -np.sum(masses * x * z)
+    inertia_tensor[1, 2] = inertia_tensor[2, 1] = -np.sum(masses * y * z)
+
+    eigenvalues = np.linalg.eigvalsh(inertia_tensor)
+    # a linear molecule has exactly one vanishing principal moment of inertia
+    # (the molecular axis); use a relative tolerance rather than an exact zero.
+    return bool(eigenvalues[0] <= 1e-6 * eigenvalues[-1])
 
 
 def dimensionality(atoms: List[Atom]) -> int:

--- a/tests/thermo/test_system.py
+++ b/tests/thermo/test_system.py
@@ -248,10 +248,36 @@ def test_dof():
     
 def test_linearity():
     atoms = [Atom(symbol='H', position=np.array([0, 0, 0]))]
-    
+
     with pytest.raises(TSValueError) as e:
         linearity(atoms)
     assert str(e.value) == "Number of atoms must be greater than 1. The system is monoatomic."
+
+
+def _atoms_at(spec, offset):
+    return [
+        Atom(symbol=symbol, position=np.array(position, dtype=float) + offset)
+        for symbol, position in spec
+    ]
+
+
+@pytest.mark.parametrize("offset", [np.zeros(3), np.array([10.0, -5.0, 3.0])])
+def test_linearity_is_translation_invariant(offset):
+    # Inertia tensor must be built from center-of-mass-relocated coordinates,
+    # so classification does not depend on where the molecule sits in space.
+    co2 = [("C", [0, 0, 0]), ("O", [0, 0, 1.16]), ("O", [0, 0, -1.16])]
+    # water is planar; when it lies in a coordinate plane the old second-moment
+    # tensor produced a spurious zero eigenvalue and called it linear.
+    water = [("O", [0, 0, 0]), ("H", [0.757, 0.586, 0]), ("H", [-0.757, 0.586, 0])]
+
+    assert linearity(_atoms_at(co2, offset)) is True
+    assert linearity(_atoms_at(water, offset)) is False
+
+
+def test_linearity_detects_off_axis_linear_molecule():
+    # A linear molecule not aligned to a Cartesian axis must still be linear.
+    hcn = [("H", [0, 0, 0]), ("C", [0.6, 0.6, 0.6]), ("N", [1.2, 1.2, 1.2])]
+    assert linearity(_atoms_at(hcn, np.zeros(3))) is True
              
 
 def test_rotational_symmetry_number_accepts_property(monkeypatch):


### PR DESCRIPTION
Closes #49.

`linearity()` built its tensor from raw atom positions using the second-moment form (`Σ mᵢ rᵢ⊗rᵢ`) and tested the smallest eigenvalue with an exact `== 0`. Two consequences:
- **Position-dependent:** an off-origin linear molecule (e.g. CO₂ shifted away from the origin) was misclassified as non-linear.
- **Planar molecules misclassified:** a planar molecule lying in a coordinate plane (e.g. water in the xy-plane) gets a spurious zero eigenvalue in the second-moment tensor and was called linear.

`linearity()` feeds `dof()` (3N−5 for linear vs 3N−6 for non-linear), so a wrong classification corrupts the vibrational degrees of freedom and thus the thermochemistry for any geometry that is not pre-centered.

## Fix
Build the **true inertia tensor** (`Σ mᵢ(|rᵢ|²I − rᵢ⊗rᵢ)`) from **center-of-mass-relocated** coordinates — mirroring `thermo.py::_compute_inertia_tensor` — and decide the vanishing principal moment with a **relative tolerance** instead of an exact zero.

## Tests
- Translation invariance for a linear (CO₂) and a planar non-linear (water) molecule, including the in-coordinate-plane case that previously misfired.
- An off-axis linear molecule (HCN along a diagonal) is still detected as linear.

No existing expectations changed (the old exact-zero check already returned non-linear for real off-axis geometries). 144 passed, 0 skipped (suite run with DFTB+ binaries); pylint 7.98/10.