### PR TITLE
Add thermochemistry screening over a set of molecules

### DIFF
--- a/ThermoScreening/__init__.py
+++ b/ThermoScreening/__init__.py
@@ -49,3 +49,7 @@ if log_file_env_var and (logging_env_var or "").lower() != "off":
 
 if config.log_file_name is None:
     config.log_file_name = f"ThermoScreening_{execution_start_time}.log"
+
+# Public screening entry point (imported last so the type-checking hook and
+# logging configuration above are already in place).
+from ThermoScreening.thermo.screening import screen  # noqa: E402  pylint: disable=wrong-import-position

--- a/ThermoScreening/cli/thermo.py
+++ b/ThermoScreening/cli/thermo.py
@@ -10,10 +10,11 @@ from ThermoScreening.cli.dftb_setup import (
     install_slakos,
 )
 from ThermoScreening.thermo.api import execute
+from ThermoScreening.thermo.screening import screen
 from ThermoScreening.version import __version__
 
 
-DFTB_COMMANDS = {"setup-dftb", "doctor"}
+SUBCOMMANDS = {"setup-dftb", "doctor", "screen"}
 
 
 def _run_parser():
@@ -54,6 +55,34 @@ def _command_parser():
         help="Check DFTB+ executables and Slater-Koster parameter configuration.",
     )
 
+    screen_parser = subparsers.add_parser(
+        "screen",
+        help="Run thermochemistry screening over a set of molecules.",
+    )
+    screen_parser.add_argument(
+        "source",
+        help="Directory of .xyz/.gen structures, or a .csv manifest "
+        "(columns: path, optional name/charge).",
+    )
+    screen_parser.add_argument(
+        "-o", "--out", default="results",
+        help="Output stem; writes <out>.csv and <out>.json. Default 'results'.",
+    )
+    screen_parser.add_argument(
+        "--charge", type=float, default=0.0,
+        help="Charge for directory input and manifest rows without a charge.",
+    )
+    screen_parser.add_argument(
+        "--temperature", type=float, default=298.15, help="Temperature in K.",
+    )
+    screen_parser.add_argument(
+        "--pressure", type=float, default=101325.0, help="Pressure in Pa.",
+    )
+    screen_parser.add_argument(
+        "--directory", default="screening",
+        help="Root working directory; each molecule runs in <directory>/<name>.",
+    )
+
     return parser
 
 
@@ -69,7 +98,7 @@ def parse_args(argv=None):
     if argv is None:
         argv = sys.argv[1:]
 
-    if argv and argv[0] in DFTB_COMMANDS:
+    if argv and argv[0] in SUBCOMMANDS:
         parser = _command_parser()
         args = parser.parse_args(argv)
     else:
@@ -109,6 +138,27 @@ def run_doctor():
     return 0 if all(item.ok for item in diagnostics) else 1
 
 
+def run_screen(parser_args):
+    """
+    Run thermochemistry screening over a set of molecules.
+    """
+
+    results = screen(
+        parser_args.source,
+        out=parser_args.out,
+        charge=parser_args.charge,
+        temperature=parser_args.temperature,
+        pressure=parser_args.pressure,
+        directory=parser_args.directory,
+    )
+
+    failed = sum(1 for record in results if record["status"] != "ok")
+    print(f"Screened {len(results)} molecules ({failed} failed).")
+    print(f"Results: {parser_args.out}.csv, {parser_args.out}.json")
+
+    return 1 if failed else 0
+
+
 def main():
     """
     Main function to run the thermo cli. It parses the command line arguments
@@ -132,6 +182,9 @@ def main():
 
     if command == "doctor":
         return run_doctor()
+
+    if command == "screen":
+        return run_screen(parser_args)
 
     input_file = parser_args.input_file
     verbose = parser_args.verbose

--- a/ThermoScreening/thermo/__init__.py
+++ b/ThermoScreening/thermo/__init__.py
@@ -4,3 +4,4 @@ from .cell import Cell
 from .inputFileReader import InputFileReader
 from .system import System
 from .thermo import Thermo
+from .screening import screen

--- a/ThermoScreening/thermo/screening.py
+++ b/ThermoScreening/thermo/screening.py
@@ -1,0 +1,196 @@
+"""
+Thermochemistry screening over a set of molecules.
+
+``screen`` runs the DFTB+ geometry-optimisation/Hessian/modes pipeline for each
+molecule in its own working directory and collects the key thermochemical
+quantities into a results table (CSV and JSON). A failing molecule is recorded
+with an error status and does not stop the run.
+"""
+
+import csv
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import ase.io
+
+from ThermoScreening import __package_name__
+from ThermoScreening.calculator.dftbplus import dftb_3ob_parameters
+from ThermoScreening.exceptions import TSValueError
+from ThermoScreening.utils.custom_logging import setup_logger
+
+from .api import dftbplus_thermo
+
+logger = logging.getLogger(__package_name__).getChild("screening")
+logger = setup_logger(logger)
+
+_STRUCTURE_SUFFIXES = (".xyz", ".gen")
+_RESULT_FIELDS = [
+    "name",
+    "path",
+    "charge",
+    "status",
+    "E_hartree",
+    "H_hartree",
+    "G_hartree",
+    "S_cal_per_mol_K",
+    "Cv_cal_per_mol_K",
+    "error",
+]
+
+
+@dataclass
+class ScreeningJob:
+    """A single molecule to screen."""
+
+    name: str
+    path: Path
+    charge: float
+
+
+def _jobs_from_directory(directory: Path, charge: float):
+    jobs = [
+        ScreeningJob(name=path.stem, path=path, charge=charge)
+        for path in sorted(directory.iterdir())
+        if path.suffix.lower() in _STRUCTURE_SUFFIXES
+    ]
+    if not jobs:
+        raise TSValueError(f"No .xyz or .gen structures found in '{directory}'.")
+    return jobs
+
+
+def _jobs_from_manifest(manifest: Path, charge: float):
+    base = manifest.parent
+    jobs = []
+    with open(manifest, newline="", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            if "path" not in row or not row["path"]:
+                raise TSValueError(f"Manifest '{manifest}' needs a 'path' column.")
+            path = Path(row["path"])
+            if not path.is_absolute():
+                path = base / path
+            row_charge = row.get("charge")
+            jobs.append(
+                ScreeningJob(
+                    name=row.get("name") or path.stem,
+                    path=path,
+                    charge=float(row_charge) if row_charge not in (None, "") else charge,
+                )
+            )
+    if not jobs:
+        raise TSValueError(f"Manifest '{manifest}' lists no molecules.")
+    return jobs
+
+
+def _load_jobs(source, charge: float):
+    source = Path(source)
+    if source.is_dir():
+        return _jobs_from_directory(source, charge)
+    if source.suffix.lower() == ".csv":
+        return _jobs_from_manifest(source, charge)
+    raise TSValueError(
+        f"Screening input must be a directory or a .csv manifest, got '{source}'."
+    )
+
+
+def _thermo_summary(thermo):
+    return {
+        "E_hartree": thermo.total_energy("H"),
+        "H_hartree": thermo.total_enthalpy("H"),
+        "G_hartree": thermo.total_gibbs_free_energy("H"),
+        "S_cal_per_mol_K": thermo.total_entropy("cal/(mol*K)"),
+        "Cv_cal_per_mol_K": thermo.total_heat_capacity("cal/(mol*K)"),
+    }
+
+
+def _write_results(results, out):
+    stem = Path(str(out)).with_suffix("")
+    if stem.parent != Path(""):
+        stem.parent.mkdir(parents=True, exist_ok=True)
+
+    csv_path = stem.with_suffix(".csv")
+    with open(csv_path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=_RESULT_FIELDS)
+        writer.writeheader()
+        for record in results:
+            writer.writerow({field: record.get(field, "") for field in _RESULT_FIELDS})
+
+    json_path = stem.with_suffix(".json")
+    json_path.write_text(json.dumps(results, indent=2), encoding="utf-8")
+
+    return csv_path, json_path
+
+
+def screen(
+    source,
+    out="results",
+    charge=0.0,
+    temperature=298.15,
+    pressure=101325,
+    directory="screening",
+    parameters=None,
+):
+    """
+    Run a thermochemistry screen over a set of molecules.
+
+    Parameters
+    ----------
+    source : str
+        A directory of ``.xyz``/``.gen`` structures (all run at ``charge``), or
+        a ``.csv`` manifest with ``path`` and optional ``name``/``charge`` columns.
+    out : str
+        Output stem; results are written to ``<out>.csv`` and ``<out>.json``.
+    charge : float
+        Charge used for directory input and for manifest rows without a charge.
+    temperature : float
+        Temperature in K.
+    pressure : float
+        Pressure in Pa.
+    directory : str
+        Root working directory; each molecule runs in ``<directory>/<name>``.
+    parameters : dict, optional
+        DFTB+ Hamiltonian parameters. Defaults to the bundled 3ob set.
+
+    Returns
+    -------
+    list of dict
+        One result record per molecule, including failed ones (status="error").
+    """
+    parameters = dict(dftb_3ob_parameters) if parameters is None else parameters
+    jobs = _load_jobs(source, charge)
+    root = Path(directory)
+
+    results = []
+    for job in jobs:
+        record = {
+            "name": job.name,
+            "path": str(job.path),
+            "charge": job.charge,
+            "status": "ok",
+            "error": "",
+        }
+        logger.info(f"Screening {job.name} (charge {job.charge})")
+        try:
+            atoms = ase.io.read(str(job.path))
+            thermo = dftbplus_thermo(
+                atoms,
+                temperature=temperature,
+                pressure=pressure,
+                charge=job.charge,
+                directory=str(root / job.name),
+                **parameters,
+            )
+            record.update(_thermo_summary(thermo))
+        except Exception as exc:  # pylint: disable=broad-except
+            # isolate failures so one bad molecule does not abort the screen
+            record["status"] = "error"
+            record["error"] = str(exc)
+            # warning, not error: the active custom logger raises on error and
+            # we must keep screening the remaining molecules
+            logger.warning(f"Screening failed for {job.name}: {exc}")
+        results.append(record)
+
+    csv_path, json_path = _write_results(results, out)
+    logger.info(f"Wrote {csv_path} and {json_path}")
+    return results

--- a/tests/thermo/test_screening.py
+++ b/tests/thermo/test_screening.py
@@ -1,0 +1,156 @@
+import csv
+import json
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from ThermoScreening.exceptions import TSValueError
+from ThermoScreening.thermo import screening
+
+
+class _FakeThermo:
+    def total_energy(self, unit):
+        return -10.0
+
+    def total_enthalpy(self, unit):
+        return -9.0
+
+    def total_gibbs_free_energy(self, unit):
+        return -11.0
+
+    def total_entropy(self, unit):
+        return 50.0
+
+    def total_heat_capacity(self, unit):
+        return 6.0
+
+
+def _write_xyz(path):
+    path.write_text("1\n\nH 0.0 0.0 0.0\n", encoding="utf-8")
+
+
+def test_load_jobs_from_directory(tmp_path):
+    _write_xyz(tmp_path / "mol_b.xyz")
+    _write_xyz(tmp_path / "mol_a.xyz")
+    (tmp_path / "notes.txt").write_text("ignore me", encoding="utf-8")
+
+    jobs = screening._load_jobs(tmp_path, charge=2.0)
+
+    assert [job.name for job in jobs] == ["mol_a", "mol_b"]  # sorted, .txt ignored
+    assert all(job.charge == 2.0 for job in jobs)
+
+
+def test_load_jobs_from_manifest(tmp_path):
+    _write_xyz(tmp_path / "a.xyz")
+    _write_xyz(tmp_path / "b.xyz")
+    manifest = tmp_path / "m.csv"
+    manifest.write_text(
+        "name,path,charge\nfirst,a.xyz,-1\n,b.xyz,\n", encoding="utf-8"
+    )
+
+    jobs = screening._load_jobs(manifest, charge=0.0)
+
+    assert jobs[0].name == "first" and jobs[0].charge == -1.0
+    assert jobs[0].path == tmp_path / "a.xyz"  # resolved relative to the manifest
+    assert jobs[1].name == "b"  # blank name falls back to the file stem
+    assert jobs[1].charge == 0.0  # blank charge falls back to the default
+
+
+def test_load_jobs_rejects_unknown_source(tmp_path):
+    bad = tmp_path / "thing.txt"
+    bad.write_text("x", encoding="utf-8")
+    with pytest.raises(TSValueError):
+        screening._load_jobs(bad, charge=0.0)
+
+
+def test_load_jobs_rejects_empty_directory(tmp_path):
+    with pytest.raises(TSValueError):
+        screening._load_jobs(tmp_path, charge=0.0)
+
+
+def test_screen_collects_results_and_isolates_failures(monkeypatch, tmp_path):
+    _write_xyz(tmp_path / "good.xyz")
+    _write_xyz(tmp_path / "bad.xyz")
+    manifest = tmp_path / "m.csv"
+    manifest.write_text(
+        "name,path,charge\ngood,good.xyz,0\nbad,bad.xyz,-99\n", encoding="utf-8"
+    )
+
+    captured = {"dirs": []}
+
+    def fake_thermo(atoms, charge=0, directory=None, **kwargs):
+        captured["dirs"].append(directory)
+        if charge == -99:
+            raise RuntimeError("kaboom")
+        return _FakeThermo()
+
+    monkeypatch.setattr(screening, "dftbplus_thermo", fake_thermo)
+
+    out = tmp_path / "out" / "results"
+    results = screening.screen(
+        str(manifest), out=str(out), directory=str(tmp_path / "runs")
+    )
+
+    # one failure does not abort the run
+    assert [record["status"] for record in results] == ["ok", "error"]
+    assert results[1]["error"] == "kaboom"
+    assert results[0]["G_hartree"] == -11.0
+
+    # each molecule ran in its own directory
+    assert str(tmp_path / "runs" / "good") in captured["dirs"]
+
+    csv_rows = list(csv.DictReader(out.with_suffix(".csv").open(encoding="utf-8")))
+    assert csv_rows[0]["name"] == "good"
+    assert csv_rows[1]["status"] == "error"
+    assert set(screening._RESULT_FIELDS) <= set(csv_rows[0].keys())
+
+    data = json.loads(out.with_suffix(".json").read_text(encoding="utf-8"))
+    assert data[1]["error"] == "kaboom"
+
+
+def test_screen_uses_default_charge_for_directory_input(monkeypatch, tmp_path):
+    _write_xyz(tmp_path / "m1.xyz")
+    charges = []
+
+    def fake_thermo(atoms, charge=0, directory=None, **kwargs):
+        charges.append(charge)
+        return _FakeThermo()
+
+    monkeypatch.setattr(screening, "dftbplus_thermo", fake_thermo)
+
+    screening.screen(
+        str(tmp_path), out=str(tmp_path / "r"), charge=-2.0,
+        directory=str(tmp_path / "runs"),
+    )
+
+    assert charges == [-2.0]
+
+
+def test_cli_parse_args_routes_screen():
+    import ThermoScreening.cli.thermo as cli
+
+    args = cli.parse_args(
+        ["screen", "molecules.csv", "-o", "out", "--charge", "-1", "--temperature", "300"]
+    )
+
+    assert args.command == "screen"
+    assert args.source == "molecules.csv"
+    assert args.out == "out"
+    assert args.charge == -1.0
+    assert args.temperature == 300.0
+
+
+def test_cli_run_screen_returns_failure_count(monkeypatch):
+    import ThermoScreening.cli.thermo as cli
+
+    monkeypatch.setattr(
+        cli, "screen", lambda *args, **kwargs: [{"status": "ok"}, {"status": "error"}]
+    )
+
+    args = Namespace(
+        source="x", out="res", charge=0.0, temperature=298.15,
+        pressure=101325.0, directory="screening",
+    )
+
+    assert cli.run_screen(args) == 1  # one molecule failed

--- a/tests/thermo/test_screening.py
+++ b/tests/thermo/test_screening.py
@@ -69,6 +69,20 @@ def test_load_jobs_rejects_empty_directory(tmp_path):
         screening._load_jobs(tmp_path, charge=0.0)
 
 
+def test_load_jobs_rejects_manifest_without_path_column(tmp_path):
+    manifest = tmp_path / "m.csv"
+    manifest.write_text("name,charge\nfoo,0\n", encoding="utf-8")
+    with pytest.raises(TSValueError, match="path"):
+        screening._load_jobs(manifest, charge=0.0)
+
+
+def test_load_jobs_rejects_empty_manifest(tmp_path):
+    manifest = tmp_path / "m.csv"
+    manifest.write_text("name,path,charge\n", encoding="utf-8")  # header only
+    with pytest.raises(TSValueError, match="no molecules"):
+        screening._load_jobs(manifest, charge=0.0)
+
+
 def test_screen_collects_results_and_isolates_failures(monkeypatch, tmp_path):
     _write_xyz(tmp_path / "good.xyz")
     _write_xyz(tmp_path / "bad.xyz")


### PR DESCRIPTION
Implements the core screening framework from #33 (first slice). Builds on the per-job directory isolation (#55) and ASE-atoms passthrough (#52).

## What it does
A \`screen()\` entry point (exported as \`ThermoScreening.screen\`) and a \`thermo screen\` CLI subcommand that, for each molecule, run the DFTB+ geometry-optimisation/Hessian/modes pipeline in its own working directory and collect the key thermochemistry into \`results.csv\` and \`results.json\`.

- **Input (both):** a directory of \`.xyz\`/\`.gen\` structures (run at a global \`--charge\`), or a CSV manifest with \`path\` plus optional \`name\`/\`charge\` columns (per-molecule charge — e.g. anthraquinone at -1/-2).
- **Output (both):** a CSV summary table and a JSON file (name, path, charge, status, E/H/G in Hartree, S/Cv in cal/(mol*K), error).
- **Error isolation:** a molecule that fails is recorded with \`status=error\` and does not abort the run.
- **Per-job isolation:** each molecule runs in \`<directory>/<name>\`.

```
# Python
from ThermoScreening import screen
screen("molecules.csv", out="results")

# CLI
thermo screen ./structures/ -o results --charge 0
thermo screen molecules.csv -o results
```

## Tests
- Job loading from a directory and a CSV manifest (per-row + default charge, relative path resolution), and rejection of empty/unknown inputs.
- \`screen()\` with the pipeline mocked: collects results, writes CSV + JSON, runs each molecule in its own directory, and isolates a failing molecule.
- CLI routing for the \`screen\` subcommand and the failure-count return code.
- Verified locally with the real DFTB+ binaries over a directory of CH4/H2O/NH3 plus a deliberately broken structure: the three succeed (entropies 44.44 / 45.05 / 45.97 cal/(mol*K), matching literature), the broken one is isolated as an error.

152 passed, 5 skipped (no binaries); pylint 8.09/10.

## Deferred to follow-ups (not in this PR)
- Resume/checkpoint (this PR always recomputes, per the agreed scope).
- Parallel execution (chdir-based isolation is correct for sequential and multi-process batches; per-thread parallelism would need the calculators to thread a directory through).