### PR TITLE
Mechanical lint cleanup across the package

### DIFF
--- a/ThermoScreening/__init__.py
+++ b/ThermoScreening/__init__.py
@@ -1,3 +1,5 @@
+"""ThermoScreening: DFTB+ thermochemistry screening package."""
+
 import logging
 import os
 import time

--- a/ThermoScreening/calculator/__init__.py
+++ b/ThermoScreening/calculator/__init__.py
@@ -1,1 +1,3 @@
+"""Calculator backends for ThermoScreening."""
+
 from .dftbplus import Geoopt, Hessian, Modes

--- a/ThermoScreening/calculator/dftbplus.py
+++ b/ThermoScreening/calculator/dftbplus.py
@@ -1,3 +1,5 @@
+"""DFTB+ calculators: geometry optimisation, Hessian, and vibrational modes."""
+
 import os
 import shutil
 import subprocess
@@ -121,7 +123,6 @@ class Geoopt(Dftb):
 
         self.calculate(atoms)
 
-        return None
 
     def potential_energy(self):
         """
@@ -221,7 +222,6 @@ class Hessian(Dftb):
 
         self.calculate(atoms)
 
-        return None
 
     def read(self):
         """
@@ -278,7 +278,6 @@ class Modes:
         # read the vibrational modes
         self.wave_numbers = self.read()
 
-        return None
 
     def write(self):
         """
@@ -304,7 +303,6 @@ class Modes:
         with open("modes_in.hsd", "w") as f:
             f.write(string)
 
-        return None
 
     def calculate(self):
         """
@@ -328,7 +326,6 @@ class Modes:
         with open("modes.out", "w") as output:
             subprocess.run(["modes"], stdout=output, check=True)
 
-        return None
 
     def read(self):
         """

--- a/ThermoScreening/cli/__init__.py
+++ b/ThermoScreening/cli/__init__.py
@@ -1,3 +1,5 @@
+"""Command-line interface for ThermoScreening."""
+
 from .thermo import main
 from ..utils import print_header
 

--- a/ThermoScreening/cli/thermo.py
+++ b/ThermoScreening/cli/thermo.py
@@ -1,3 +1,5 @@
+"""The ``thermo`` command-line entry point."""
+
 from argparse import ArgumentParser
 import sys
 import time

--- a/ThermoScreening/exceptions.py
+++ b/ThermoScreening/exceptions.py
@@ -4,9 +4,9 @@ A module defining exceptions of the ThermoScreening package.
 
 class ThermoScreeningException(Exception):
     """Base class for exceptions in this package."""
-    
+
 class TSValueError(ThermoScreeningException):
     """Exception raised for errors in the input value."""
-    
+
 class TSNotImplementedError(ThermoScreeningException):
     """Exception raised for not implemented methods."""

--- a/ThermoScreening/thermo/__init__.py
+++ b/ThermoScreening/thermo/__init__.py
@@ -1,3 +1,5 @@
+"""Thermochemistry API for ThermoScreening."""
+
 from .api import read_xyz, read_gen, read_vib_file, read_coord, read_vibrational, unit_length, unit_energy, unit_mass, run_thermo, execute
 from .atoms import Atom
 from .cell import Cell

--- a/ThermoScreening/thermo/api.py
+++ b/ThermoScreening/thermo/api.py
@@ -1,3 +1,5 @@
+"""High-level thermochemistry functions: coordinate/frequency I/O and run helpers."""
+
 import logging
 import os
 from contextlib import contextmanager
@@ -181,14 +183,13 @@ def read_coord(coord_file: str, engine: str):
         if coord_file.endswith(".xyz"):
             data_N, data_atoms, data_xyz, cell, pbc = read_xyz(coord_file)
             return data_N, data_atoms, data_xyz, cell, pbc
-        elif coord_file.endswith(".gen"):
+        if coord_file.endswith(".gen"):
             data_N, data_atoms, data_xyz, cell_vectors, pbc = read_gen(coord_file)
             return data_N, data_atoms, data_xyz, cell_vectors, pbc
-        else:
-            logger.error(
-                "The input file is not supported.",
-                exception=TSNotImplementedError
-            )
+        logger.error(
+            "The input file is not supported.",
+            exception=TSNotImplementedError
+        )
 
     else:
         logger.error(
@@ -251,11 +252,10 @@ def unit_length(engine: str):
     """
     if engine == "dftb+":
         return "Angstrom"
-    else:
-        logger.error(
-            "The engine is not supported.",
-            exception=TSNotImplementedError
-        )
+    logger.error(
+        "The engine is not supported.",
+        exception=TSNotImplementedError
+    )
 
 
 def unit_energy(engine: str):
@@ -279,11 +279,10 @@ def unit_energy(engine: str):
     """
     if engine == "dftb+":
         return "Hartree"
-    else:
-        logger.error(
-            "The engine is not supported.",
-            exception=TSNotImplementedError
-        )
+    logger.error(
+        "The engine is not supported.",
+        exception=TSNotImplementedError
+    )
 
 
 def unit_mass(engine: str):
@@ -307,11 +306,10 @@ def unit_mass(engine: str):
     """
     if engine == "dftb+":
         return "amu"
-    else:
-        logger.error(
-            "The engine is not supported.",
-            exception=TSNotImplementedError
-        )
+    logger.error(
+        "The engine is not supported.",
+        exception=TSNotImplementedError
+    )
 
 
 def unit_frequency(engine: str):
@@ -335,11 +333,10 @@ def unit_frequency(engine: str):
     """
     if engine == "dftb+":
         return "cm^-1"
-    else:
-        logger.error(
-            "The engine is not supported.",
-            exception=TSNotImplementedError
-        )
+    logger.error(
+        "The engine is not supported.",
+        exception=TSNotImplementedError
+    )
 
 
 def _atoms_from_ase(atoms):

--- a/ThermoScreening/thermo/atoms.py
+++ b/ThermoScreening/thermo/atoms.py
@@ -1,3 +1,5 @@
+"""Atom representation and element reference data."""
+
 import logging
 
 import numpy as np
@@ -45,7 +47,7 @@ class Atom:
     >>> atom.position
     array([0., 0., 0.])
     """
-    
+
     logger = logging.getLogger(__package_name__).getChild(__qualname__)
     logger = setup_logger(logger)
 
@@ -96,7 +98,7 @@ class Atom:
                 self._symbol = atomic_Symbol[int(number)].capitalize()
             except:
                 self.logger.error(
-                    "The atomic number %s is not known." % number,
+                    f"The atomic number {number} is not known.",
                     exception=TSValueError
                 )
             self._mass = atomicMasses[self._symbol.lower()]
@@ -107,7 +109,7 @@ class Atom:
                 self._number = atomicNumbers[symbol.lower()]
             except:
                 self.logger.error(
-                    "The chemical symbol %s is not known." % symbol,
+                    f"The chemical symbol {symbol} is not known.",
                     exception=TSValueError
                 )
             self._mass = atomicMasses[symbol.lower()]
@@ -225,7 +227,7 @@ class Atom:
                 self._number = atomicNumbers[self._symbol.lower()]
             except:
                 self.logger.error(
-                    "The chemical symbol %s is not known." % symbol,
+                    f"The chemical symbol {symbol} is not known.",
                     exception=TSValueError
                 )
 
@@ -238,14 +240,14 @@ class Atom:
                 self._symbol = atomic_Symbol[int(number)].capitalize()
             except:
                 self.logger.error(
-                    "The atomic number %s is not known." % number,
+                    f"The atomic number {number} is not known.",
                     exception=TSValueError
                 )
             self._mass = atomicMasses[self._symbol.lower()]
             self._configuration = atomicElectronConfigurations[self._symbol.lower()]
         if position is not None:
-            
-            self.position = position        
+
+            self.position = position
 
 
 atomic_Symbol = atomicNumbersReverse

--- a/ThermoScreening/thermo/cell.py
+++ b/ThermoScreening/thermo/cell.py
@@ -1,3 +1,5 @@
+"""Periodic cell helpers."""
+
 import numpy as np
 
 

--- a/ThermoScreening/thermo/inputFileReader.py
+++ b/ThermoScreening/thermo/inputFileReader.py
@@ -1,3 +1,5 @@
+"""Reader for ThermoScreening key=value input files."""
+
 import logging
 
 from ThermoScreening.exceptions import TSValueError
@@ -14,7 +16,7 @@ class InputFileReader:
         The input file.
 
     """
-    
+
     logger = logging.getLogger(__package_name__).getChild(__qualname__)
     logger = setup_logger(logger)
 
@@ -58,7 +60,6 @@ class InputFileReader:
         self._read()
         self._check()
 
-        return None
 
     def _read(self):
         """
@@ -84,7 +85,6 @@ class InputFileReader:
             key, value = line.split("=", maxsplit=1)
             self._dictionary[key.strip()] = value.strip()
 
-        return None
 
     def _check(self):
         """
@@ -101,8 +101,7 @@ class InputFileReader:
         """
         self._check_required_keys()
         self._check_known_keys()
-        
-        return None
+
 
     def _check_required_keys(self):
         """
@@ -120,11 +119,10 @@ class InputFileReader:
         for key in self.required_keys:
             if key not in self._dictionary.keys():
                 self.logger.error(
-                    "The key {} is not set in the input file.".format(key),
+                    f"The key {key} is not set in the input file.",
                     exception=TSValueError
                 )
-            
-        return None
+
 
     def _check_known_keys(self):
         """
@@ -142,8 +140,7 @@ class InputFileReader:
         for key in self._dictionary.keys():
             if key not in self.required_keys:
                 self.logger.error(
-                    "The key {} is not known.".format(key),
+                    f"The key {key} is not known.",
                     exception=TSValueError
                 )
 
-        return None

--- a/ThermoScreening/thermo/system.py
+++ b/ThermoScreening/thermo/system.py
@@ -1,3 +1,5 @@
+"""Molecular system model with symmetry and degree-of-freedom analysis."""
+
 import logging
 import warnings
 import numpy as np
@@ -159,13 +161,13 @@ def dimensionality(atoms: List[Atom]) -> int:
         or (np.array_equal(x, zero_array) and np.array_equal(y, zero_array))
     ):
         return 1
-    elif (
+    if (
         np.array_equal(z, zero_array)
         or np.array_equal(y, zero_array)
         or np.array_equal(x, zero_array)
     ):
         return 2
-    elif (
+    if (
         np.array_equal(z, zero_array)
         and np.array_equal(y, zero_array)
         and np.array_equal(x, zero_array)
@@ -197,13 +199,12 @@ def dim(atoms: List[Atom]) -> int:
     number_of_atoms = len(atoms)
     if number_of_atoms == 1:
         return 1
-    elif number_of_atoms > 1:
+    if number_of_atoms > 1:
         return dimensionality(atoms)
-    else:
-        System.logger.error(
-            "The number of atoms must be greater than 0.",
-            exception=TSValueError
-        )
+    System.logger.error(
+        "The number of atoms must be greater than 0.",
+        exception=TSValueError
+    )
 
 
 def dof(atoms: List[Atom]) -> int:
@@ -229,15 +230,14 @@ def dof(atoms: List[Atom]) -> int:
     number_of_atoms = len(atoms)
     if number_of_atoms == 1:
         return 3
-    elif number_of_atoms > 1:
+    if number_of_atoms > 1:
         return (
             (3 * number_of_atoms - 5) if linearity(atoms) else (3 * number_of_atoms - 6)
         )
-    else:
-        System.logger.error(
-            "The number of atoms must be greater than 0.",
-            exception=TSValueError
-        )
+    System.logger.error(
+        "The number of atoms must be greater than 0.",
+        exception=TSValueError
+    )
 
 
 def spin(charge: float) -> float:
@@ -255,8 +255,7 @@ def spin(charge: float) -> float:
 
     if (charge % 2.0) == 0:
         return 0.0
-    else:
-        return 0.5
+    return 0.5
 
 
 def rotational_symmetry_number(atoms: List[Atom]) -> int:
@@ -580,7 +579,7 @@ class System:
     >>> system.atoms
     [Atom(symbol='H', position=[0.0, 0.0, 0.0], mass=1.0), Atom(symbol='H', position=[0.0, 0.0, 1.0], mass=1.0)]
     """
-    
+
     logger = logging.getLogger(__package_name__).getChild(__name__)
     logger = setup_logger(logger)
 
@@ -627,19 +626,19 @@ class System:
             If the number of atoms is less than 1.
             If the vibrational frequencies are not provided.
         """
-        
+
         if atoms is None:
             self.logger.error(
                 "Atoms must be provided.",
                 exception=TSValueError
             )
-            
+
         if len(atoms) == 0:
             self.logger.error(
                 "The number of atoms must be greater than 0.",
                 exception=TSValueError
             )
-            
+
         if vibrational_frequencies is None:
             self.logger.error(
                 "Vibrational frequencies must be provided.",

--- a/ThermoScreening/thermo/thermo.py
+++ b/ThermoScreening/thermo/thermo.py
@@ -1,3 +1,5 @@
+"""Rigid-rotor/harmonic-oscillator thermochemistry calculation."""
+
 import numpy as np
 
 import logging
@@ -43,7 +45,7 @@ class Thermo:
     run()
         Calculates the thermochemical properties of the system.
     """
-    
+
     logger = logging.getLogger(__package_name__).getChild(__name__)
     logger = setup_logger(logger)
 
@@ -79,22 +81,22 @@ class Thermo:
         -------
         None
         """
-        if pressure == None:
+        if pressure is None:
             self.logger.error(
                 "The pressure is not given.",
                 exception=TSValueError
             )
-        if temperature == None:
+        if temperature is None:
             self.logger.error(
                 "The temperature is not given.",
                 exception=TSValueError
             )
-        if system == None:
+        if system is None:
             self.logger.error(
                 "The system is not given.",
                 exception=TSValueError
             )
-        if engine == None:
+        if engine is None:
             self.logger.error(
                 "The engine is not given.",
                 exception=TSValueError
@@ -124,7 +126,6 @@ class Thermo:
         self._reloc_coord = None
         self._atomic_masses = self._system.atomic_masses()
 
-        return None
 
     def run(self):
         """
@@ -143,7 +144,6 @@ class Thermo:
         self._compute_thermochemical_properties()
         self._summary()
 
-        return None
 
     def _transform_units(self):
         """
@@ -180,7 +180,6 @@ class Thermo:
                 exception=TSValueError
             )
 
-        return None
 
     def _relocate_to_cm(self):
         """
@@ -194,7 +193,6 @@ class Thermo:
         self._reloc_coord = self._system.coord()
         self._reloc_coord -= self._system.center_of_mass
 
-        return None
 
     def _compute_inertia_tensor(self):
         """
@@ -223,7 +221,6 @@ class Thermo:
         self._inertia_tensor[1, 2] = -np.sum(m * y * z)
         self._inertia_tensor[2, 1] = self._inertia_tensor[1, 2]
 
-        return None
 
     def _compute_rotational_partition_function(self):
         """
@@ -260,7 +257,6 @@ class Thermo:
             / (np.power(self._rotational_temperature_xyz, 1 / 2))
         )
 
-        return None
 
     def _compute_rotational_entropy(self):
         """
@@ -276,7 +272,6 @@ class Thermo:
             / PhysicalConstants["cal"]
         )
 
-        return None
 
     def _compute_rotational_energy(self):
         """
@@ -298,7 +293,6 @@ class Thermo:
             (3 / 2) * PhysicalConstants["R"] / PhysicalConstants["cal"]
         )
 
-        return None
 
     def _rotational_contribution(self):
         """
@@ -317,7 +311,6 @@ class Thermo:
         self._compute_rotational_energy()
         self._compute_rotational_heat_capacity()
 
-        return None
 
     def _compute_vibrational_partition_function(self):
         """
@@ -342,7 +335,6 @@ class Thermo:
             / (1 - np.exp(-self._vib_temp_K / self._temperature))
         )
 
-        return None
 
     def _compute_vibrational_entropy(self):
         """
@@ -367,7 +359,6 @@ class Thermo:
             / PhysicalConstants["cal"]
         )
 
-        return None
 
     def _compute_vibrational_energy(self):
         """
@@ -406,7 +397,6 @@ class Thermo:
             / PhysicalConstants["cal"]
         )
 
-        return None
 
     def _compute_vibrational_heat_capacity(self):
         """
@@ -428,7 +418,6 @@ class Thermo:
             )
             / PhysicalConstants["cal"]
         )
-        return None
 
     def _vibrational_contribution(self):
         """
@@ -455,7 +444,6 @@ class Thermo:
 
         self._electronic_partition_function = 2 * self._system._spin + 1
 
-        return None
 
     def _compute_electronic_entropy(self):
         """
@@ -471,7 +459,6 @@ class Thermo:
             * np.log(self._electronic_partition_function)
             / PhysicalConstants["cal"]
         )
-        return None
 
     def _compute_electronic_energy(self):
         """
@@ -484,7 +471,6 @@ class Thermo:
 
         self._electronic_energy = 0 / PhysicalConstants["cal"]
 
-        return None
 
     def _compute_electronic_heat_capacity(self):
         """
@@ -497,7 +483,6 @@ class Thermo:
 
         self._electronic_heat_capacity = 0 / PhysicalConstants["cal"]
 
-        return None
 
     def _electronic_contribution(self):
         """
@@ -513,7 +498,6 @@ class Thermo:
         self._compute_electronic_energy()
         self._compute_electronic_heat_capacity()
 
-        return None
 
     def _compute_translational_partition_function(self):
         """
@@ -532,7 +516,6 @@ class Thermo:
             (3 / 2),
         ) * (PhysicalConstants["kB"] * self._temperature / self._pressure)
 
-        return None
 
     def _compute_translational_entropy(self):
         """
@@ -549,7 +532,6 @@ class Thermo:
             / PhysicalConstants["cal"]
         )
 
-        return None
 
     def _compute_translational_energy(self):
         """
@@ -568,7 +550,6 @@ class Thermo:
             / PhysicalConstants["cal"]
         )
 
-        return None
 
     def _compute_translational_heat_capacity(self):
         """
@@ -583,7 +564,6 @@ class Thermo:
             3 / 2 * PhysicalConstants["R"] / PhysicalConstants["cal"]
         )
 
-        return None
 
     def _translational_contribution(self):
         """
@@ -598,7 +578,6 @@ class Thermo:
         self._compute_translational_energy()
         self._compute_translational_heat_capacity()
 
-        return None
 
     def _compute_thermochemical_properties(self):
         """
@@ -666,7 +645,6 @@ class Thermo:
             + self._translational_heat_capacity
         )
 
-        return None
 
     def _summary(self):
         """
@@ -703,7 +681,6 @@ class Thermo:
             + self._total_gibbs_free_energy_Hartree_per_mol
         )
 
-        return None
 
     def total_energy(self, unit: str) -> float:
         """
@@ -727,15 +704,14 @@ class Thermo:
 
         if unit == "H":
             return _real_scalar(self._total_energy_Hartree_per_mol)
-        elif unit == "kcal":
+        if unit == "kcal":
             return _real_scalar(self._total_energy_kcal)
-        elif unit == "cal":
+        if unit == "cal":
             return _real_scalar(self._total_energy)
-        else:
-            self.logger.error(
-                "The unit is not supported.",
-                exception=TSValueError
-            )
+        self.logger.error(
+            "The unit is not supported.",
+            exception=TSValueError
+        )
 
     def total_enthalpy(self, unit: str) -> float:
         """
@@ -759,15 +735,14 @@ class Thermo:
 
         if unit == "H":
             return _real_scalar(self._total_enthalpy_Hartree_per_mol)
-        elif unit == "kcal":
+        if unit == "kcal":
             return _real_scalar(self._total_enthalpy_kcal)
-        elif unit == "cal":
+        if unit == "cal":
             return _real_scalar(self._total_enthalpy)
-        else:
-            self.logger.error(
-                "The unit is not supported.",
-                exception=TSValueError
-            )
+        self.logger.error(
+            "The unit is not supported.",
+            exception=TSValueError
+        )
 
     def total_entropy(self, unit: str) -> float:
         """
@@ -791,13 +766,12 @@ class Thermo:
 
         if unit == "H/T":
             return _real_scalar(self._total_entropy_Hartree_per_mol)
-        elif unit == "cal/(mol*K)":
+        if unit == "cal/(mol*K)":
             return _real_scalar(self._total_entropy)
-        else:
-            self.logger.error(
-                "The unit is not supported.",
-                exception=TSValueError
-            )
+        self.logger.error(
+            "The unit is not supported.",
+            exception=TSValueError
+        )
 
     def total_gibbs_free_energy(self, unit: str) -> float:
         """
@@ -821,15 +795,14 @@ class Thermo:
 
         if unit == "H":
             return _real_scalar(self._total_gibbs_free_energy_Hartree_per_mol)
-        elif unit == "kcal":
+        if unit == "kcal":
             return _real_scalar(self._total_gibbs_free_energy_kcal)
-        elif unit == "cal":
+        if unit == "cal":
             return _real_scalar(self._total_gibbs_free_energy)
-        else:
-            self.logger.error(
-                "The unit is not supported.",
-                exception=TSValueError
-            )
+        self.logger.error(
+            "The unit is not supported.",
+            exception=TSValueError
+        )
 
     def total_heat_capacity(self, unit: str) -> float:
         """
@@ -853,18 +826,17 @@ class Thermo:
 
         if unit == "cal/(mol*K)":
             return _real_scalar(self._total_heatcapacity)
-        elif unit == "H/T":
+        if unit == "H/T":
             return _real_scalar(
                 self._total_heatcapacity
                 * PhysicalConstants["cal"]
                 / PhysicalConstants["H"]
                 / PhysicalConstants["N_A"]
             )
-        else:
-            self.logger.error(
-                "The unit is not supported.",
-                exception=TSValueError
-            )
+        self.logger.error(
+            "The unit is not supported.",
+            exception=TSValueError
+        )
 
     def total_EeZPE(self) -> float:
         """

--- a/ThermoScreening/utils/__init__.py
+++ b/ThermoScreening/utils/__init__.py
@@ -1,2 +1,4 @@
+"""Utility helpers for ThermoScreening."""
+
 from .header import print_header
 from .physicalConstants import PhysicalConstants

--- a/ThermoScreening/utils/header.py
+++ b/ThermoScreening/utils/header.py
@@ -1,3 +1,5 @@
+"""Program header/banner."""
+
 import sys
 
 from beartype.typing import Any

--- a/ThermoScreening/utils/physicalConstants.py
+++ b/ThermoScreening/utils/physicalConstants.py
@@ -1,3 +1,5 @@
+"""Physical constants and unit conversions."""
+
 import numpy as np
 """
 Physical constants and conversion factors that is used in the program.
@@ -20,16 +22,16 @@ PhysicalConstants = {
     "c": 299792458, # m/s
     "kB": 1.380649 * 10**(-23), # J K^-1
     "R": 8.314462618, # J mol^-1 K^-1
-    "N_A": 6.02214076 * 10**(23), # mol^-1 
+    "N_A": 6.02214076 * 10**(23), # mol^-1
     "u": 1.66053906660 * 10**(-27), # kg
     "H": 4.3597447222071 * 10**(-18), # J
     "cal": 4.184, # J
     "A": 10**(-10), # m
     "HztoGHz": 10**(-9), # GHz
-    "eV": 1.602176634 * 10**(-19), # J 
+    "eV": 1.602176634 * 10**(-19), # J
     # NOT USED:
-    # "pi": 3.14159265358979323846,  
-    # "kcal": 4184, # J  
+    # "pi": 3.14159265358979323846,
+    # "kcal": 4184, # J
     # "angstrom": 10**(-10), # m
     # "bohr_radius": 5.29177210903 * 10**(-11), # m
 }

--- a/ThermoScreening/version.py
+++ b/ThermoScreening/version.py
@@ -1,3 +1,5 @@
+"""Package version helpers."""
+
 from importlib.metadata import PackageNotFoundError, version
 
 


### PR DESCRIPTION
Behaviour-preserving lint cleanup, driven by ruff + pylint and guarded by the full test suite (159 passed with the DFTB+ binaries, 0 skipped). No logic changes.

## Changes (all mechanical)
- Strip trailing whitespace; add missing final newlines.
- Remove useless `return` / `return None` at the end of functions.
- Drop superfluous `else` after `return` (dedent only; the prior `else` bodies call `logger.error(..., exception=...)`, which raises, so control flow is unchanged).
- `== None` -> `is None`.
- Convert leftover `%`-formatted strings to f-strings.
- Add module docstrings (skipping the setuptools_scm-generated `__version__.py`).

## Result
- pylint **7.40 -> 8.79**.
- Remaining lint is structural and intentionally left out of this pass: `attribute-defined-outside-init` (Thermo sets totals in `run()`), `invalid-name` (overlaps #37), `inconsistent-return-statements` (the log-and-raise pattern), `too-many-arguments`, `cyclic-import`. Those want dedicated, careful PRs.