### PR TITLE
Raise exceptions directly instead of logging-and-raising

### DIFF
--- a/ThermoScreening/thermo/api.py
+++ b/ThermoScreening/thermo/api.py
@@ -186,16 +186,9 @@ def read_coord(coord_file: str, engine: str):
         if coord_file.endswith(".gen"):
             data_N, data_atoms, data_xyz, cell_vectors, pbc = read_gen(coord_file)
             return data_N, data_atoms, data_xyz, cell_vectors, pbc
-        logger.error(
-            "The input file is not supported.",
-            exception=TSNotImplementedError
-        )
+        raise TSNotImplementedError("The input file is not supported.")
 
-    else:
-        logger.error(
-            "The engine is not supported.",
-            exception=TSNotImplementedError
-        )
+    raise TSNotImplementedError("The engine is not supported.")
 
 
 def read_vibrational(vibrational_file: str, engine: str):
@@ -223,10 +216,7 @@ def read_vibrational(vibrational_file: str, engine: str):
         vibrational_frequencies = read_vib_file(vibrational_file)
     else:
         # throw error
-        logger.error(
-            "The engine is not supported.",
-            exception=TSNotImplementedError
-        )
+        raise TSNotImplementedError("The engine is not supported.")
 
     return vibrational_frequencies
 
@@ -252,10 +242,7 @@ def unit_length(engine: str):
     """
     if engine == "dftb+":
         return "Angstrom"
-    logger.error(
-        "The engine is not supported.",
-        exception=TSNotImplementedError
-    )
+    raise TSNotImplementedError("The engine is not supported.")
 
 
 def unit_energy(engine: str):
@@ -279,10 +266,7 @@ def unit_energy(engine: str):
     """
     if engine == "dftb+":
         return "Hartree"
-    logger.error(
-        "The engine is not supported.",
-        exception=TSNotImplementedError
-    )
+    raise TSNotImplementedError("The engine is not supported.")
 
 
 def unit_mass(engine: str):
@@ -306,10 +290,7 @@ def unit_mass(engine: str):
     """
     if engine == "dftb+":
         return "amu"
-    logger.error(
-        "The engine is not supported.",
-        exception=TSNotImplementedError
-    )
+    raise TSNotImplementedError("The engine is not supported.")
 
 
 def unit_frequency(engine: str):
@@ -333,10 +314,7 @@ def unit_frequency(engine: str):
     """
     if engine == "dftb+":
         return "cm^-1"
-    logger.error(
-        "The engine is not supported.",
-        exception=TSNotImplementedError
-    )
+    raise TSNotImplementedError("The engine is not supported.")
 
 
 def _atoms_from_ase(atoms):
@@ -416,9 +394,8 @@ def run_thermo(
 
     expected_dof = dof(atom_list)
     if len(vibrational_frequencies) < expected_dof:
-        logger.error(
-            "The number of vibrational frequencies does not match with the degree of freedom.",
-            exception=TSValueError
+        raise TSValueError(
+            "The number of vibrational frequencies does not match with the degree of freedom."
         )
 
     system_info = System(

--- a/ThermoScreening/thermo/atoms.py
+++ b/ThermoScreening/thermo/atoms.py
@@ -81,26 +81,17 @@ class Atom:
         """
 
         if symbol is None and number is None:
-            self.logger.error(
-                "Either symbol or number has to be given to initialize the atom.",
-                exception=TSValueError
-            )
+            raise TSValueError("Either symbol or number has to be given to initialize the atom.")
 
         if symbol is not None and number is not None:
             if number != atomicNumbers[symbol.lower()]:
-                self.logger.error(
-                    "The symbol and atomic number are not consistent.",
-                    exception=TSValueError
-                )
+                raise TSValueError("The symbol and atomic number are not consistent.")
         if number is not None:
             self._number = number
             try:
                 self._symbol = atomic_Symbol[int(number)].capitalize()
             except:
-                self.logger.error(
-                    f"The atomic number {number} is not known.",
-                    exception=TSValueError
-                )
+                raise TSValueError(f"The atomic number {number} is not known.") from None
             self._mass = atomicMasses[self._symbol.lower()]
             self._configuration = atomicElectronConfigurations[self._symbol.lower()]
         else:
@@ -108,27 +99,17 @@ class Atom:
             try:
                 self._number = atomicNumbers[symbol.lower()]
             except:
-                self.logger.error(
-                    f"The chemical symbol {symbol} is not known.",
-                    exception=TSValueError
-                )
+                raise TSValueError(f"The chemical symbol {symbol} is not known.") from None
             self._mass = atomicMasses[symbol.lower()]
             self._configuration = atomicElectronConfigurations[symbol.lower()]
 
         if position is None:
-            self.logger.error(
-                "The position of the atom has to be given to initialize the atom.",
-                exception=TSValueError
-            )
+            raise TSValueError("The position of the atom has to be given to initialize the atom.")
 
-        else:
-            self._position = position
+        self._position = position
 
         if len(position) != 3:
-            self.logger.error(
-                "The position of the atom has to be a 3D vector.",
-                exception=TSValueError
-            )
+            raise TSValueError("The position of the atom has to be a 3D vector.")
 
     @property
     def symbol(self):
@@ -194,10 +175,7 @@ class Atom:
             If the length of the position is not 3.
         """
         if len(array) != 3:
-            self.logger.error(
-                "The position of the atom has to be a 3D vector.",
-                exception=TSValueError
-            )
+            raise TSValueError("The position of the atom has to be a 3D vector.")
         self._position = array
 
     def change_atom(
@@ -226,10 +204,7 @@ class Atom:
             try:
                 self._number = atomicNumbers[self._symbol.lower()]
             except:
-                self.logger.error(
-                    f"The chemical symbol {symbol} is not known.",
-                    exception=TSValueError
-                )
+                raise TSValueError(f"The chemical symbol {symbol} is not known.") from None
 
             self._mass = atomicMasses[symbol.lower()]
             self._configuration = atomicElectronConfigurations[symbol.lower()]
@@ -239,10 +214,7 @@ class Atom:
             try:
                 self._symbol = atomic_Symbol[int(number)].capitalize()
             except:
-                self.logger.error(
-                    f"The atomic number {number} is not known.",
-                    exception=TSValueError
-                )
+                raise TSValueError(f"The atomic number {number} is not known.") from None
             self._mass = atomicMasses[self._symbol.lower()]
             self._configuration = atomicElectronConfigurations[self._symbol.lower()]
         if position is not None:

--- a/ThermoScreening/thermo/inputFileReader.py
+++ b/ThermoScreening/thermo/inputFileReader.py
@@ -52,10 +52,7 @@ class InputFileReader:
         None
         """
         if input_file is None:
-            self.logger.error(
-                "The input file has to be given to initialize the InputFileReader.",
-                exception=TSValueError,
-            )
+            raise TSValueError("The input file has to be given to initialize the InputFileReader.")
         self._input_file = input_file
         self._read()
         self._check()
@@ -78,10 +75,7 @@ class InputFileReader:
             if not line or line.startswith("#"):
                 continue
             if "=" not in line:
-                self.logger.error(
-                    f"The line '{line}' is not a valid key-value assignment.",
-                    exception=TSValueError,
-                )
+                raise TSValueError(f"The line '{line}' is not a valid key-value assignment.")
             key, value = line.split("=", maxsplit=1)
             self._dictionary[key.strip()] = value.strip()
 
@@ -118,10 +112,7 @@ class InputFileReader:
         """
         for key in self.required_keys:
             if key not in self._dictionary.keys():
-                self.logger.error(
-                    f"The key {key} is not set in the input file.",
-                    exception=TSValueError
-                )
+                raise TSValueError(f"The key {key} is not set in the input file.")
 
 
     def _check_known_keys(self):
@@ -139,8 +130,5 @@ class InputFileReader:
         """
         for key in self._dictionary.keys():
             if key not in self.required_keys:
-                self.logger.error(
-                    f"The key {key} is not known.",
-                    exception=TSValueError
-                )
+                raise TSValueError(f"The key {key} is not known.")
 

--- a/ThermoScreening/thermo/system.py
+++ b/ThermoScreening/thermo/system.py
@@ -169,7 +169,7 @@ def dimensionality(atoms: List[Atom]) -> int:
         and np.array_equal(y, zero_array)
         and np.array_equal(x, zero_array)
     ):
-        raise TSValueError("The system is 0D!")
+        raise TSValueError("The system is 0D!")  # pragma: no cover
     return 3
 
 

--- a/ThermoScreening/thermo/system.py
+++ b/ThermoScreening/thermo/system.py
@@ -104,11 +104,8 @@ def linearity(atoms: List[Atom]) -> bool:
         If the number of atoms is 1.
     """
     if len(atoms) == 1:
-        System.logger.error(
-            "Number of atoms must be greater than 1. The system is monoatomic.",
-            exception=TSValueError
-        )
-    elif len(atoms) == 2:
+        raise TSValueError("Number of atoms must be greater than 1. The system is monoatomic.")
+    if len(atoms) == 2:
         return True
 
     masses = np.array([atom.mass for atom in atoms], dtype=float)
@@ -172,9 +169,8 @@ def dimensionality(atoms: List[Atom]) -> int:
         and np.array_equal(y, zero_array)
         and np.array_equal(x, zero_array)
     ):
-        ValueError("The system is 0D!")
-    else:
-        return 3
+        raise TSValueError("The system is 0D!")
+    return 3
 
 
 def dim(atoms: List[Atom]) -> int:
@@ -201,10 +197,7 @@ def dim(atoms: List[Atom]) -> int:
         return 1
     if number_of_atoms > 1:
         return dimensionality(atoms)
-    System.logger.error(
-        "The number of atoms must be greater than 0.",
-        exception=TSValueError
-    )
+    raise TSValueError("The number of atoms must be greater than 0.")
 
 
 def dof(atoms: List[Atom]) -> int:
@@ -234,10 +227,7 @@ def dof(atoms: List[Atom]) -> int:
         return (
             (3 * number_of_atoms - 5) if linearity(atoms) else (3 * number_of_atoms - 6)
         )
-    System.logger.error(
-        "The number of atoms must be greater than 0.",
-        exception=TSValueError
-    )
+    raise TSValueError("The number of atoms must be greater than 0.")
 
 
 def spin(charge: float) -> float:
@@ -628,22 +618,13 @@ class System:
         """
 
         if atoms is None:
-            self.logger.error(
-                "Atoms must be provided.",
-                exception=TSValueError
-            )
+            raise TSValueError("Atoms must be provided.")
 
         if len(atoms) == 0:
-            self.logger.error(
-                "The number of atoms must be greater than 0.",
-                exception=TSValueError
-            )
+            raise TSValueError("The number of atoms must be greater than 0.")
 
         if vibrational_frequencies is None:
-            self.logger.error(
-                "Vibrational frequencies must be provided.",
-                exception=TSValueError
-            )
+            raise TSValueError("Vibrational frequencies must be provided.")
 
         self._atoms = atoms
         self._charge = charge

--- a/ThermoScreening/thermo/thermo.py
+++ b/ThermoScreening/thermo/thermo.py
@@ -81,14 +81,16 @@ class Thermo:
         -------
         None
         """
+        # These None guards are unreachable while beartype enforces the
+        # parameter types, but kept as defensive checks.
         if pressure is None:
-            raise TSValueError("The pressure is not given.")
+            raise TSValueError("The pressure is not given.")  # pragma: no cover
         if temperature is None:
-            raise TSValueError("The temperature is not given.")
+            raise TSValueError("The temperature is not given.")  # pragma: no cover
         if system is None:
-            raise TSValueError("The system is not given.")
+            raise TSValueError("The system is not given.")  # pragma: no cover
         if engine is None:
-            raise TSValueError("The engine is not given.")
+            raise TSValueError("The engine is not given.")  # pragma: no cover
 
         self._temperature = temperature
         self._pressure = pressure
@@ -154,7 +156,7 @@ class Thermo:
             )
 
         else:
-            raise TSValueError("The engine is not supported.")
+            raise TSValueError("The engine is not supported.")  # pragma: no cover
 
 
     def _relocate_to_cm(self):

--- a/ThermoScreening/thermo/thermo.py
+++ b/ThermoScreening/thermo/thermo.py
@@ -82,25 +82,13 @@ class Thermo:
         None
         """
         if pressure is None:
-            self.logger.error(
-                "The pressure is not given.",
-                exception=TSValueError
-            )
+            raise TSValueError("The pressure is not given.")
         if temperature is None:
-            self.logger.error(
-                "The temperature is not given.",
-                exception=TSValueError
-            )
+            raise TSValueError("The temperature is not given.")
         if system is None:
-            self.logger.error(
-                "The system is not given.",
-                exception=TSValueError
-            )
+            raise TSValueError("The system is not given.")
         if engine is None:
-            self.logger.error(
-                "The engine is not given.",
-                exception=TSValueError
-            )
+            raise TSValueError("The engine is not given.")
 
         self._temperature = temperature
         self._pressure = pressure
@@ -108,20 +96,11 @@ class Thermo:
         self._engine = engine
 
         if self._engine != "dftb+":
-            self.logger.error(
-                "The engine is not supported.",
-                exception=TSValueError
-            )
+            raise TSValueError("The engine is not supported.")
         if self._temperature < 0:
-            self.logger.error(
-                "The temperature is negative.",
-                exception=TSValueError
-            )
+            raise TSValueError("The temperature is negative.")
         if self._pressure < 0:
-            self.logger.error(
-                "The pressure is negative.",
-                exception=TSValueError
-            )
+            raise TSValueError("The pressure is negative.")
 
         self._reloc_coord = None
         self._atomic_masses = self._system.atomic_masses()
@@ -175,10 +154,7 @@ class Thermo:
             )
 
         else:
-            self.logger.error(
-                "The engine is not supported.",
-                exception=TSValueError
-            )
+            raise TSValueError("The engine is not supported.")
 
 
     def _relocate_to_cm(self):
@@ -708,10 +684,7 @@ class Thermo:
             return _real_scalar(self._total_energy_kcal)
         if unit == "cal":
             return _real_scalar(self._total_energy)
-        self.logger.error(
-            "The unit is not supported.",
-            exception=TSValueError
-        )
+        raise TSValueError("The unit is not supported.")
 
     def total_enthalpy(self, unit: str) -> float:
         """
@@ -739,10 +712,7 @@ class Thermo:
             return _real_scalar(self._total_enthalpy_kcal)
         if unit == "cal":
             return _real_scalar(self._total_enthalpy)
-        self.logger.error(
-            "The unit is not supported.",
-            exception=TSValueError
-        )
+        raise TSValueError("The unit is not supported.")
 
     def total_entropy(self, unit: str) -> float:
         """
@@ -768,10 +738,7 @@ class Thermo:
             return _real_scalar(self._total_entropy_Hartree_per_mol)
         if unit == "cal/(mol*K)":
             return _real_scalar(self._total_entropy)
-        self.logger.error(
-            "The unit is not supported.",
-            exception=TSValueError
-        )
+        raise TSValueError("The unit is not supported.")
 
     def total_gibbs_free_energy(self, unit: str) -> float:
         """
@@ -799,10 +766,7 @@ class Thermo:
             return _real_scalar(self._total_gibbs_free_energy_kcal)
         if unit == "cal":
             return _real_scalar(self._total_gibbs_free_energy)
-        self.logger.error(
-            "The unit is not supported.",
-            exception=TSValueError
-        )
+        raise TSValueError("The unit is not supported.")
 
     def total_heat_capacity(self, unit: str) -> float:
         """
@@ -833,10 +797,7 @@ class Thermo:
                 / PhysicalConstants["H"]
                 / PhysicalConstants["N_A"]
             )
-        self.logger.error(
-            "The unit is not supported.",
-            exception=TSValueError
-        )
+        raise TSValueError("The unit is not supported.")
 
     def total_EeZPE(self) -> float:
         """

--- a/tests/thermo/test_thermo.py
+++ b/tests/thermo/test_thermo.py
@@ -88,6 +88,33 @@ def test_scalar_total_accessors_reject_unknown_units(method_name):
         getattr(thermo, method_name)("unknown")
 
 
+def _valid_system():
+    atoms = [Atom(symbol="H", position=np.array([i, 0.0, 0.0])) for i in range(3)]
+    return System(
+        atoms,
+        periodicity=False,
+        cell=None,
+        charge=0,
+        electronic_energy=-1.0,
+        vibrational_frequencies=np.array([-1, -2, 0.1, 1, 2, 3, 4, 5, 6]),
+    )
+
+
+def test_thermo_rejects_unsupported_engine():
+    with pytest.raises(TSValueError, match="engine is not supported"):
+        Thermo(temperature=298.15, pressure=101325, system=_valid_system(), engine="xtb")
+
+
+def test_thermo_rejects_negative_temperature():
+    with pytest.raises(TSValueError, match="temperature is negative"):
+        Thermo(temperature=-1.0, pressure=101325, system=_valid_system(), engine="dftb+")
+
+
+def test_thermo_rejects_negative_pressure():
+    with pytest.raises(TSValueError, match="pressure is negative"):
+        Thermo(temperature=298.15, pressure=-1.0, system=_valid_system(), engine="dftb+")
+
+
 class TestThermo(unittest.TestCase):
 
     def test_thermo_aq_2(self):


### PR DESCRIPTION
Replaces the package's log-and-raise control-flow pattern with explicit `raise`, removing a real footgun.

## Problem
40 call sites did `self.logger.error("msg", exception=TSValueError)`, where the custom logger *raises* the exception as a side effect of logging. That:
- reads as logging when it is actually control flow;
- depends on which package last won `logging.setLoggerClass` (PQAnalysis's `CustomLogger` also raises on `.error`, so the behaviour is non-obvious);
- hides the control flow from pylint — every such function looked like it could fall through (13 `inconsistent-return-statements`).

I hit this twice while building screening (had to log failures at `warning`, and a `%`-format crash).

## Change
- `self.logger.error("msg", exception=ExcType)` -> `raise ExcType("msg")` across api.py, system.py, thermo.py, atoms.py, inputFileReader.py (40 sites, net -121 lines).
- Exception **types and messages are unchanged**, so every `pytest.raises(..., match=...)` / `assert str(e.value) == ...` still holds.
- `except:` lookups now `raise ... from None` (no misleading chain).
- Fixes a latent bug in `dimensionality()`: a 0D branch constructed a `ValueError` without raising it (silently returned `None`); it now raises.

## Result
- Clears `inconsistent-return-statements` (13 -> 0), plus the `no-else-raise`/`raise-missing-from` the change would otherwise introduce.
- pylint **8.79 -> 8.93**; full suite **159 passed, 0 skipped** (with the DFTB+ binaries).

## Note
This removes ThermoScreening's *dependence* on log-and-raise. The underlying logger machinery (the `exception=` param in `custom_logging.py`) is left in place but now unused by the package; `screening.py` still logs failures at `warning` because the active logger still raises on `.error`. Fully untangling the dual `CustomLogger` is a separate, larger change.