### PR TITLE
Reject imaginary vibrational frequencies instead of returning NaN

### DIFF
--- a/ThermoScreening/thermo/thermo.py
+++ b/ThermoScreening/thermo/thermo.py
@@ -438,7 +438,19 @@ class Thermo:
         Returns
         -------
         None
+
+        Raises
+        ------
+        TSValueError
+            If a kept vibrational frequency is imaginary (non-positive), which
+            would otherwise make the harmonic formulas return NaN.
         """
+
+        if np.any(self._system.real_vibrational_frequencies <= 0):
+            raise TSValueError(
+                "Imaginary (non-positive) vibrational frequencies are present; "
+                "the geometry is not a minimum."
+            )
 
         self._compute_vibrational_partition_function()
         self._compute_vibrational_entropy()

--- a/tests/thermo/test_thermo.py
+++ b/tests/thermo/test_thermo.py
@@ -168,6 +168,18 @@ def test_total_entropy_matches_ase(symbols, positions, freqs, dof, geometry, sig
     assert ts_total == pytest.approx(ase_total, abs=0.05)
 
 
+def test_thermo_rejects_imaginary_vibrational_mode():
+    # an imaginary (negative) mode in the kept dof set used to give NaN; it now
+    # raises (the geometry is not a minimum)
+    with pytest.raises(TSValueError, match="[Ii]maginary"):
+        _ts_thermo(
+            ["O", "H", "H"],
+            [[0, 0, 0.119], [0, 0.763, -0.477], [0, -0.763, -0.477]],
+            [-500.0, 3657.0, 3756.0],
+            3,
+        )
+
+
 def test_rotational_contribution_handles_linear_and_monatomic():
     # linear and monatomic species used to give -inf rotational entropy
     co2 = _ts_thermo(["C", "O", "O"], [[0, 0, 0], [0, 0, 1.16], [0, 0, -1.16]],


### PR DESCRIPTION
Closes #60.

An imaginary (non-positive) vibrational mode in the kept `dof` set made the harmonic-oscillator formulas return `NaN` entropy/Gibbs **silently** (`np.log(1 - exp(-theta/T))` of a negative argument). For the screening framework that means a `NaN` row instead of a clean `error`.

## Fix
`_vibrational_contribution` raises `TSValueError` when `real_vibrational_frequencies` contains a non-positive value — a non-minimum geometry is now reported as an error (and isolated by the screening loop) instead of producing `NaN`.

## Why the kept set, not `has_imaginary_frequencies`
Real DFTB+ output carries small **negative** translation/rotation frequencies in the *input* (e.g. `frequency.txt` starts `-35.7, -14.34, -3.23`) that `frequency_dof` correctly **drops**. Guarding on `System.has_imaginary_frequencies` (the full input) would wrongly reject every real molecule; the kept set of a true minimum is strictly positive (verified: the anthraquinone fixture keeps 66 modes, min 40.6 cm⁻¹, and still computes S = 103.743).

## Tests
A 3-atom system with an imaginary mode in the kept set now raises `TSValueError`; the existing nonlinear/anthraquinone regressions (negative input, positive kept) are unchanged. 163 passed; pylint 8.90.

Found by the thermochemistry audit alongside #59; #61 (spin/multiplicity) remains.