### PR TITLE
Support explicit spin; default to the minimum-spin ground state

### DIFF
--- a/ThermoScreening/thermo/api.py
+++ b/ThermoScreening/thermo/api.py
@@ -344,6 +344,7 @@ def run_thermo(
     engine="dftb+",
     charge=0.0,
     atoms=None,
+    spin=None,
 ):
     """
     Run the thermo calculation. Returns thermo calculation object.
@@ -405,6 +406,7 @@ def run_thermo(
         vibrational_frequencies=vibrational_frequencies,
         pbc=pbc,
         charge=charge,
+        spin=spin,
     )
 
     thermo_setup = Thermo(
@@ -500,6 +502,7 @@ def dftbplus_thermo(
         pressure=101325,
         charge=0.0,
         directory=None,
+        spin=None,
         **kwargs
     ):
     """
@@ -554,6 +557,7 @@ def dftbplus_thermo(
             energy=potential_energy,
             engine='dftb+',
             charge=charge,
+            spin=spin,
         )
 
     return thermo

--- a/ThermoScreening/thermo/screening.py
+++ b/ThermoScreening/thermo/screening.py
@@ -47,11 +47,12 @@ class ScreeningJob:
     name: str
     path: Path
     charge: float
+    spin: float | None = None
 
 
-def _jobs_from_directory(directory: Path, charge: float):
+def _jobs_from_directory(directory: Path, charge: float, spin=None):
     jobs = [
-        ScreeningJob(name=path.stem, path=path, charge=charge)
+        ScreeningJob(name=path.stem, path=path, charge=charge, spin=spin)
         for path in sorted(directory.iterdir())
         if path.suffix.lower() in _STRUCTURE_SUFFIXES
     ]
@@ -60,7 +61,7 @@ def _jobs_from_directory(directory: Path, charge: float):
     return jobs
 
 
-def _jobs_from_manifest(manifest: Path, charge: float):
+def _jobs_from_manifest(manifest: Path, charge: float, spin=None):
     base = manifest.parent
     jobs = []
     with open(manifest, newline="", encoding="utf-8") as handle:
@@ -71,11 +72,13 @@ def _jobs_from_manifest(manifest: Path, charge: float):
             if not path.is_absolute():
                 path = base / path
             row_charge = row.get("charge")
+            row_spin = row.get("spin")
             jobs.append(
                 ScreeningJob(
                     name=row.get("name") or path.stem,
                     path=path,
                     charge=float(row_charge) if row_charge not in (None, "") else charge,
+                    spin=float(row_spin) if row_spin not in (None, "") else spin,
                 )
             )
     if not jobs:
@@ -83,12 +86,12 @@ def _jobs_from_manifest(manifest: Path, charge: float):
     return jobs
 
 
-def _load_jobs(source, charge: float):
+def _load_jobs(source, charge: float, spin=None):
     source = Path(source)
     if source.is_dir():
-        return _jobs_from_directory(source, charge)
+        return _jobs_from_directory(source, charge, spin)
     if source.suffix.lower() == ".csv":
-        return _jobs_from_manifest(source, charge)
+        return _jobs_from_manifest(source, charge, spin)
     raise TSValueError(
         f"Screening input must be a directory or a .csv manifest, got '{source}'."
     )
@@ -130,6 +133,7 @@ def screen(
     pressure=101325,
     directory="screening",
     parameters=None,
+    spin=None,
 ):
     """
     Run a thermochemistry screen over a set of molecules.
@@ -138,7 +142,8 @@ def screen(
     ----------
     source : str
         A directory of ``.xyz``/``.gen`` structures (all run at ``charge``), or
-        a ``.csv`` manifest with ``path`` and optional ``name``/``charge`` columns.
+        a ``.csv`` manifest with ``path`` and optional ``name``/``charge``/``spin``
+        columns.
     out : str
         Output stem; results are written to ``<out>.csv`` and ``<out>.json``.
     charge : float
@@ -151,6 +156,9 @@ def screen(
         Root working directory; each molecule runs in ``<directory>/<name>``.
     parameters : dict, optional
         DFTB+ Hamiltonian parameters. Defaults to the bundled 3ob set.
+    spin : float, optional
+        Spin quantum number S applied to molecules without a manifest ``spin``;
+        defaults to an electron-count guess per molecule.
 
     Returns
     -------
@@ -158,7 +166,7 @@ def screen(
         One result record per molecule, including failed ones (status="error").
     """
     parameters = dict(dftb_3ob_parameters) if parameters is None else parameters
-    jobs = _load_jobs(source, charge)
+    jobs = _load_jobs(source, charge, spin)
     root = Path(directory)
 
     results = []
@@ -179,6 +187,7 @@ def screen(
                 pressure=pressure,
                 charge=job.charge,
                 directory=str(root / job.name),
+                spin=job.spin,
                 **parameters,
             )
             record.update(_thermo_summary(thermo))

--- a/ThermoScreening/thermo/system.py
+++ b/ThermoScreening/thermo/system.py
@@ -231,22 +231,32 @@ def dof(atoms: List[Atom]) -> int:
     raise TSValueError("The number of atoms must be greater than 0.")
 
 
-def spin(charge: float) -> float:
+def default_spin(atoms: List[Atom], charge: float) -> float:
     """
-    Calculates the spin of the system.
+    Guess the spin quantum number S as the minimum-spin ground state from the
+    electron-count parity.
+
+    electrons = sum(atomic numbers) - charge; S = 0.0 for an even electron count
+    (a closed-shell singlet - ~99% of even-electron molecules) and 0.5 for an odd
+    one (a doublet radical - essentially always the ground state). This reliably
+    covers closed-shell molecules and simple radicals; even-electron high-spin
+    ground states (e.g. the triplet O2) need an explicit spin.
+
     Parameters
     ----------
+    atoms : List[Atom]
+        The atoms of the system.
     charge : float
+        The charge of the system.
 
     Returns
     -------
     float
-        The spin of the system.
+        The default spin quantum number S.
     """
 
-    if (charge % 2.0) == 0:
-        return 0.0
-    return 0.5
+    electrons = sum(atom.number for atom in atoms) - charge
+    return 0.0 if round(electrons) % 2 == 0 else 0.5
 
 
 def rotational_symmetry_number(atoms: List[Atom]) -> int:
@@ -585,6 +595,7 @@ class System:
         solvent: str | None = None,
         electronic_energy: float | None = None,
         vibrational_frequencies: np.ndarray | None = None,
+        spin: float | None = None,
     ) -> None:
         """
         Initializes the System with the given parameters.
@@ -682,7 +693,15 @@ class System:
         if electronic_energy is None:
             self._electronic_energy = 0.0
 
-        self._spin = spin(self._charge)
+        # Default to the minimum-spin ground state from the electron count
+        # (even -> singlet, odd -> doublet); even-electron high-spin species
+        # (triplet O2, ...) must set the spin explicitly.
+        if spin is None:
+            self._spin = default_spin(self._atoms, self._charge)
+        else:
+            if spin < 0:
+                raise TSValueError("The spin must be non-negative.")
+            self._spin = float(spin)
 
     @property
     def atoms(self) -> List[Atom]:

--- a/tests/thermo/test_screening.py
+++ b/tests/thermo/test_screening.py
@@ -57,6 +57,38 @@ def test_load_jobs_from_manifest(tmp_path):
     assert jobs[1].charge == 0.0  # blank charge falls back to the default
 
 
+def test_load_jobs_reads_spin_from_manifest(tmp_path):
+    _write_xyz(tmp_path / "a.xyz")
+    _write_xyz(tmp_path / "b.xyz")
+    manifest = tmp_path / "m.csv"
+    manifest.write_text(
+        "name,path,charge,spin\nradical,a.xyz,0,0.5\nclosed,b.xyz,0,\n",
+        encoding="utf-8",
+    )
+
+    jobs = screening._load_jobs(manifest, charge=0.0, spin=None)
+
+    assert jobs[0].spin == 0.5
+    assert jobs[1].spin is None  # blank -> default (electron-count guess)
+
+
+def test_screen_passes_spin_to_dftbplus_thermo(monkeypatch, tmp_path):
+    _write_xyz(tmp_path / "mol.xyz")
+    manifest = tmp_path / "m.csv"
+    manifest.write_text("name,path,charge,spin\nmol,mol.xyz,0,1.0\n", encoding="utf-8")
+
+    captured = {}
+
+    def fake_thermo(atoms, spin=None, **kwargs):
+        captured["spin"] = spin
+        return _FakeThermo()
+
+    monkeypatch.setattr(screening, "dftbplus_thermo", fake_thermo)
+    screening.screen(str(manifest), out=str(tmp_path / "r"), directory=str(tmp_path / "runs"))
+
+    assert captured["spin"] == 1.0
+
+
 def test_load_jobs_rejects_unknown_source(tmp_path):
     bad = tmp_path / "thing.txt"
     bad.write_text("x", encoding="utf-8")

--- a/tests/thermo/test_system.py
+++ b/tests/thermo/test_system.py
@@ -4,7 +4,7 @@ import math
 import numpy as np
 from ase.atoms import Atoms
 import ThermoScreening.thermo.system as system_module
-from ThermoScreening.thermo.system import System, dim, dof, linearity, rotational_symmetry_number
+from ThermoScreening.thermo.system import System, dim, dof, linearity, rotational_symmetry_number, default_spin
 from ThermoScreening.thermo.atoms import Atom
 from ThermoScreening.thermo.cell import Cell
 from ThermoScreening.exceptions import TSValueError
@@ -278,6 +278,42 @@ def test_linearity_detects_off_axis_linear_molecule():
     # A linear molecule not aligned to a Cartesian axis must still be linear.
     hcn = [("H", [0, 0, 0]), ("C", [0.6, 0.6, 0.6]), ("N", [1.2, 1.2, 1.2])]
     assert linearity(_atoms_at(hcn, np.zeros(3))) is True
+
+
+@pytest.mark.parametrize(
+    "symbols,charge,expected",
+    [
+        (["O", "H", "H"], 0, 0.0),       # water, 10 electrons (even) -> singlet
+        (["C", "H", "H", "H"], 0, 0.5),  # methyl radical, 9 electrons (odd) -> doublet
+        (["O", "O"], 0, 0.0),            # O2: even electrons -> minimum-spin guesses singlet
+        (["O", "H"], -1, 0.0),           # hydroxide anion, 10 electrons (even) -> singlet
+    ],
+)
+def test_default_spin_from_electron_count(symbols, charge, expected):
+    atoms = [Atom(symbol=s, position=np.array([i * 1.2, 0.0, 0.0]))
+             for i, s in enumerate(symbols)]
+    assert default_spin(atoms, charge) == expected
+
+
+def test_system_accepts_explicit_spin():
+    # an explicit spin overrides the guess, e.g. triplet O2 (even electrons)
+    atoms = [Atom(symbol="O", position=np.array([0.0, 0, 0])),
+             Atom(symbol="O", position=np.array([1.2, 0, 0]))]
+    system = System(
+        atoms, periodicity=False, cell=None, charge=0, spin=1.0,
+        electronic_energy=0.0, vibrational_frequencies=np.array([1580.0]),
+    )
+    assert system.spin == 1.0
+
+
+def test_system_rejects_negative_spin():
+    atoms = [Atom(symbol="H", position=np.array([0.0, 0, 0])),
+             Atom(symbol="H", position=np.array([1.0, 0, 0]))]
+    with pytest.raises(TSValueError, match="spin must be non-negative"):
+        System(
+            atoms, periodicity=False, cell=None, charge=0, spin=-1.0,
+            electronic_energy=0.0, vibrational_frequencies=np.array([1580.0]),
+        )
              
 
 def test_rotational_symmetry_number_accepts_property(monkeypatch):
@@ -538,7 +574,7 @@ class TestSystem(unittest.TestCase):
 
         assert system.charge == 0
 
-        assert system.spin == 0
+        assert system.spin == 0.5  # 3 H atoms -> 3 electrons (doublet, minimum-spin default)
 
         assert system.number_of_atoms == 3
 

--- a/tests/thermo/test_thermo.py
+++ b/tests/thermo/test_thermo.py
@@ -180,6 +180,20 @@ def test_thermo_rejects_imaginary_vibrational_mode():
         )
 
 
+def test_explicit_spin_sets_electronic_entropy():
+    # triplet O2 (S=1) -> q_elec = 2S+1 = 3 -> S_elec = R ln 3
+    atoms = [Atom(symbol="O", position=np.array([0.0, 0, 0])),
+             Atom(symbol="O", position=np.array([1.2, 0, 0]))]
+    system = System(
+        atoms, periodicity=False, cell=None, charge=0, spin=1.0,
+        electronic_energy=0.0, vibrational_frequencies=np.array([1580.0]),
+    )
+    thermo = Thermo(temperature=_T, pressure=_P, system=system, engine="dftb+")
+    thermo.run()
+
+    assert thermo._electronic_entropy == pytest.approx(_R_CALMOLK * np.log(3))
+
+
 def test_rotational_contribution_handles_linear_and_monatomic():
     # linear and monatomic species used to give -inf rotational entropy
     co2 = _ts_thermo(["C", "O", "O"], [[0, 0, 0], [0, 0, 1.16], [0, 0, -1.16]],


### PR DESCRIPTION
Closes #61.

Electronic entropy (`q_elec = 2S+1`, `S_elec = R ln q`) took its spin from `spin(charge)` — **charge parity** — which is wrong for open-shell species.

## Change
- Replace it with `default_spin(atoms, charge)`: the **minimum-spin ground state** from the electron-count parity — `even → singlet` (S=0), `odd → doublet` (S=0.5). Even electron count is a singlet ~99% of the time, and an odd count is essentially always a doublet, so this auto-handles closed-shell molecules **and** simple radicals (e.g. every 1-electron-reduced redox species) correctly.
- Add an explicit, validated (non-negative) `spin` argument to `System`, threaded through `run_thermo`, `dftbplus_thermo`, and `screen` (optional `spin` manifest column) for the cases the guess cannot know: **even-electron high-spin ground states** (triplet O2 → `spin=1`, → `S_elec = R ln 3`).

```python
System(atoms, charge=0, spin=1.0, ...)   # triplet O2 (even electrons, user decides)
# radicals (odd electrons) are auto-guessed as doublets
```

## Tests
- `default_spin` electron-count parametrized (water/O2/hydroxide → 0; methyl radical → 0.5); explicit-spin override; negative-spin rejection.
- Triplet O2 (`spin=1`) → `S_elec = R ln 3`.
- Manifest `spin` column → `ScreeningJob.spin`; `screen` passes it to `dftbplus_thermo`.

172 passed; pylint 8.86.

Follow-up (separate PR, once this lands): opt-in **spin-polarised DFTB+** so a declared/guessed open-shell spin also drives the calculation (verified 3ob spin constants ready). Closes out the thermochemistry audit (#59 rotational, #62 imaginary modes, #61 spin).