### PR TITLE
Add the xTB backends to environment.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,15 @@ For development and tests:
 python -m pip install -e ".[test,lint]"
 ```
 
-For a Conda-based development environment with DFTB+ included:
+For a Conda-based development environment with all calculation backends
+(DFTB+, `modes`, xtb, tblite) included:
 
 ```bash
 conda env create -f environment.yml
 conda activate thermoscreening
 ```
+
+Then `thermo doctor` should report every backend as found.
 
 ## DFTB+ Setup
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,10 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.12
-  - dftbplus
+  # calculation backends (compiled programs; pip cannot install these)
+  - dftbplus        # DFTB+ engine: provides `dftb+` and `modes`
+  - xtb             # native xtb binary, for `--engine xtb-cli`
+  - tblite-python   # GFN-xTB via tblite, for `--engine xtb`
   - pip
   - pip:
       - "-e .[test,lint]"


### PR DESCRIPTION
`environment.yml` already installed DFTB+ but predates the xTB engines (#68, #70). Add the xTB backends so `conda env create -f environment.yml` provisions **every** calculation engine in one command.

```yaml
dependencies:
  - python>=3.12
  - dftbplus        # DFTB+ engine: `dftb+` and `modes`
  - xtb             # native xtb binary, for --engine xtb-cli
  - tblite-python   # GFN-xTB via tblite, for --engine xtb
  - pip
  - pip:
      - "-e .[test,lint]"
```

After `conda env create -f environment.yml && conda activate thermoscreening`, `thermo doctor` reports every backend as found (pairs with #71). README updated to say the env covers all backends.

Verified the three backends resolve on conda-forge (dftbplus-25.1 nompi, xtb-6.6.1, tblite-python-0.3.0); YAML validated.

This is the "installable through the project" follow-up: the compiled backends (DFTB+/modes/xtb/tblite) can't be pip-installed, so the conda env is how the project bundles them, while `thermo setup-dftb` handles the Slater-Koster and GBSA parameter files.