### PR TITLE
Add a Sphinx documentation site (#32)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,26 @@
+name: Docs
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # setuptools_scm needs the tags/history
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install the package and docs dependencies
+        run: python -m pip install -e ".[docs]"
+      - name: Build the documentation
+        run: python -m sphinx -b html docs docs/_build/html
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docs-html
+          path: docs/_build/html

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@
 
 ThermoScreening calculates thermochemical properties for molecular systems and provides a foundation for screening molecule sets. It currently supports thermochemistry workflows from DFTB+ inputs and exposes Python APIs for reading coordinates, parsing vibrational data, and running thermodynamic post-processing.
 
+## Documentation
+
+Structured documentation (installation, usage, configuration, and the API
+reference) is built with Sphinx from the `docs/` directory:
+
+```bash
+python -m pip install -e ".[docs]"
+python -m sphinx -b html docs docs/_build/html   # open docs/_build/html/index.html
+```
+
 ## Features
 
 - Thermochemistry calculations for molecular systems

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,48 @@
+API reference
+=============
+
+High-level pipeline
+-------------------
+
+.. autofunction:: ThermoScreening.thermo.api.dftbplus_thermo
+.. autofunction:: ThermoScreening.thermo.api.xtb_thermo
+.. autofunction:: ThermoScreening.thermo.api.xtb_cli_thermo
+.. autofunction:: ThermoScreening.thermo.api.run_thermo
+.. autofunction:: ThermoScreening.thermo.api.execute
+
+Screening
+---------
+
+.. autofunction:: ThermoScreening.thermo.screening.screen
+.. autoclass:: ThermoScreening.thermo.screening.ScreeningJob
+   :members:
+
+Conformer generation
+--------------------
+
+.. autofunction:: ThermoScreening.thermo.conformers.generate
+.. autofunction:: ThermoScreening.thermo.conformers.write_conformers
+
+Thermochemistry core
+--------------------
+
+.. autoclass:: ThermoScreening.thermo.system.System
+
+.. autoclass:: ThermoScreening.thermo.thermo.Thermo
+   :members: total_energy, total_enthalpy, total_gibbs_free_energy,
+             total_entropy, total_heat_capacity, total_EeGtot, electronic_energy
+
+Coordinate and frequency readers
+--------------------------------
+
+.. autofunction:: ThermoScreening.thermo.api.read_xyz
+.. autofunction:: ThermoScreening.thermo.api.read_gen
+.. autofunction:: ThermoScreening.thermo.api.read_coord
+.. autofunction:: ThermoScreening.thermo.api.read_vibrational
+
+Backend setup
+-------------
+
+.. autofunction:: ThermoScreening.cli.dftb_setup.install_slakos
+.. autofunction:: ThermoScreening.cli.dftb_setup.install_gbsa_param
+.. autofunction:: ThermoScreening.cli.dftb_setup.check_dftb_setup

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,37 @@
+"""Sphinx configuration for the ThermoScreening documentation."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(".."))
+
+project = "ThermoScreening"
+author = "Stefanie Kröll, Josef M. Gallmetzer"
+copyright = "2026, the ThermoScreening authors"
+
+try:
+    from ThermoScreening.version import __version__ as release
+except Exception:  # pragma: no cover - version file may be absent in a bare checkout
+    release = ""
+version = release
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+]
+
+autodoc_typehints = "description"
+napoleon_numpy_docstring = True
+napoleon_google_docstring = False
+
+# autodoc imports the package; the optional calculation backends (tblite, xtb,
+# dftb+) are imported lazily, so only mock what might be absent on a minimal
+# docs builder.
+autodoc_mock_imports = ["tblite"]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+html_theme = "alabaster"
+html_static_path = []

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,0 +1,61 @@
+Configuration
+=============
+
+Engines and methods
+-------------------
+
++---------------+----------------------------+-------------------------------------------+
+| ``engine``    | Backend                    | Notes                                     |
++===============+============================+===========================================+
+| ``dftb+``     | DFTB+                      | ``--parameter-set 3ob`` (DFTB3) or        |
+| (default)     |                            | ``mio`` (DFTB2); needs ``DFTB_PREFIX``    |
++---------------+----------------------------+-------------------------------------------+
+| ``xtb``       | GFN-xTB via tblite         | in-process, gas phase only                |
++---------------+----------------------------+-------------------------------------------+
+| ``xtb-cli``   | native ``xtb`` binary      | open-shell + charge + implicit solvation  |
++---------------+----------------------------+-------------------------------------------+
+
+For the xtb engines, ``--method`` selects ``GFN2-xTB`` (default) or ``GFN1-xTB``.
+
+Options
+-------
+
+``--solvent <name>``
+    GBSA/ALPB implicit solvation (``water``, ``dmso``, ``acetonitrile``,
+    ``thf``, ...). Applies to ``dftb+`` and ``xtb-cli``. With DFTB+ the GBSA
+    parameters are GFN-xTB-fit, so solvation free energies are qualitative.
+
+``--quasi-rrho``
+    Use Grimme's quasi-RRHO vibrational entropy, which tames the entropy of
+    low-frequency modes (recommended for flexible molecules).
+
+``--charge`` / manifest ``charge`` column
+    Total charge. Applied to directory input, or per-row in a CSV manifest.
+
+Spin / multiplicity
+    Resolved automatically from the electron count (even -> singlet, odd ->
+    doublet); an explicit spin ``S`` can be given per manifest row (``spin``
+    column) or via the Python API for cases like triplets. ``round(2*S)``
+    unpaired electrons drive both the (spin-polarised) calculation and the
+    electronic entropy ``R ln(2S+1)``.
+
+``--temperature`` / ``--pressure``
+    Thermodynamic conditions (default 298.15 K, 101325 Pa = 1 atm). Note that
+    tabulated standard entropies use 1 bar (100000 Pa).
+
+``--resume``
+    Reuse the successful records from a prior ``<out>.json`` and only (re)run the
+    missing or previously-failed molecules. Results are written incrementally.
+
+Screening input
+---------------
+
+``thermo screen`` accepts either:
+
+- a **directory** of ``.xyz``/``.gen`` structures (all run at ``--charge``), or
+- a **CSV manifest** with a ``path`` column and optional ``name``, ``charge``
+  and ``spin`` columns.
+
+Results are written to ``<out>.csv`` and ``<out>.json`` with the electronic
+energy (``Eelec_hartree``), the thermal corrections, the absolute Gibbs free
+energy (``G_total_hartree``), entropy and heat capacity.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,35 @@
+ThermoScreening
+===============
+
+ThermoScreening computes molecular thermochemistry and screens sets of molecules.
+It drives DFTB+ and GFN-xTB, runs geometry optimisation, Hessian and normal-mode
+analysis, and evaluates the ideal-gas thermochemistry (entropy, enthalpy, Gibbs
+free energy, heat capacity), with implicit solvation, quasi-RRHO, and conformer
+generation.
+
+Features
+--------
+
+- **Engines**: DFTB+ (3ob / mio parameter sets), GFN-xTB via tblite
+  (``--engine xtb``), and the native ``xtb`` binary (``--engine xtb-cli``,
+  which adds implicit solvation of charged radicals).
+- **Thermochemistry** validated against ASE ``IdealGasThermo`` and native xtb.
+- **Implicit solvation** (GBSA/ALPB), **spin polarisation** for open-shell
+  species, and **Grimme quasi-RRHO** vibrational entropy.
+- **Batch screening** with per-molecule error isolation and ``--resume``.
+- **Conformer generation** from SMILES (RDKit ETKDG).
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents
+
+   installation
+   usage
+   configuration
+   api
+
+Indices
+-------
+
+* :ref:`genindex`
+* :ref:`modindex`

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,58 @@
+Installation
+============
+
+The Python package installs with pip, but the calculation **backends** (DFTB+,
+``modes``, ``xtb``, ``tblite``) are compiled programs distributed via
+conda-forge and cannot be installed with pip.
+
+Package only
+------------
+
+.. code-block:: bash
+
+   python -m pip install .
+   # for development and tests
+   python -m pip install -e ".[test,lint]"
+
+Full environment (recommended)
+------------------------------
+
+The bundled Conda environment installs the package **and** every backend:
+
+.. code-block:: bash
+
+   conda env create -f environment.yml
+   conda activate thermoscreening
+
+After this, ``thermo doctor`` should report every backend as found.
+
+Backends
+--------
+
++-------------------+------------------------------------------+--------------------------------------------+
+| Backend           | Needed for                               | Install                                    |
++===================+==========================================+============================================+
+| ``dftb+``,        | the DFTB+ engine                         | ``conda install -c conda-forge dftbplus``  |
+| ``modes``         |                                          |                                            |
++-------------------+------------------------------------------+--------------------------------------------+
+| ``xtb``           | ``--engine xtb-cli`` (native xtb)        | ``conda install -c conda-forge xtb``       |
++-------------------+------------------------------------------+--------------------------------------------+
+| ``tblite``        | ``--engine xtb`` (in-process GFN-xTB)    | ``conda install -c conda-forge             |
+|                   |                                          | tblite-python``                            |
++-------------------+------------------------------------------+--------------------------------------------+
+
+DFTB+ and Slater-Koster setup
+-----------------------------
+
+The DFTB+ engine needs Slater-Koster (``.skf``) parameter files, located via the
+``DFTB_PREFIX`` environment variable. ThermoScreening can download the supported
+sets and the GBSA solvation parameters for you:
+
+.. code-block:: bash
+
+   thermo setup-dftb --parameter-set 3ob      # or: --parameter-set mio
+   thermo setup-dftb --solvent water          # a GBSA solvent parameter file
+   export DFTB_PREFIX="$HOME/.local/share/thermoscreening/slakos/3ob-3-1/"
+
+``thermo doctor`` checks the executables, ``DFTB_PREFIX``, and the optional xTB
+backends, and prints the exact install command for anything missing.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -77,4 +77,8 @@ End-to-end example
 
 The ``examples/`` directory in the repository contains a complete DFTB+
 thermochemistry input (``thermo.in``) together with the optimised geometry,
-frequencies and energy it consumes.
+frequencies and energy it consumes. Run it directly with:
+
+.. code-block:: bash
+
+   thermo examples/thermo.in

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,80 @@
+Usage
+=====
+
+Command line
+------------
+
+The ``thermo`` command has four subcommands.
+
+``thermo doctor``
+    Report which backends (dftb+, modes, DFTB_PREFIX + a Slater-Koster file, and
+    the optional xtb/tblite) are available.
+
+``thermo setup-dftb``
+    Download a Slater-Koster parameter set (``--parameter-set 3ob|mio``) or a
+    GBSA solvent parameter file (``--solvent <name>``).
+
+``thermo conformers``
+    Generate conformers from a SMILES (RDKit ETKDG) and write them as ``.xyz``
+    files, ready to screen:
+
+    .. code-block:: bash
+
+       thermo conformers "CCCC" --out-dir butane --max-conformers 10
+       thermo screen butane --engine xtb-cli
+
+``thermo screen``
+    Run the thermochemistry pipeline over a directory of ``.xyz``/``.gen``
+    structures or a ``.csv`` manifest, writing ``<out>.csv`` and ``<out>.json``:
+
+    .. code-block:: bash
+
+       # DFTB+ (3ob) with water solvation and quasi-RRHO entropy
+       thermo screen molecules/ --parameter-set 3ob --solvent water --quasi-rrho
+
+       # native xtb, radical anions in solution
+       thermo screen molecules/ --engine xtb-cli --solvent water
+
+       # resume an interrupted screen
+       thermo screen molecules/ -o results --resume
+
+Python API
+----------
+
+A single molecule through DFTB+:
+
+.. code-block:: python
+
+   from ase.build import molecule
+   from ThermoScreening.thermo.api import dftbplus_thermo
+   from ThermoScreening.calculator.dftbplus import dftb_3ob_parameters
+
+   thermo = dftbplus_thermo(molecule("H2O"), **dftb_3ob_parameters)
+   print(thermo.total_entropy("cal/(mol*K)"))       # ~45 cal/mol/K
+   print(thermo.total_gibbs_free_energy("H"))
+
+The GFN-xTB engines (no Slater-Koster files needed):
+
+.. code-block:: python
+
+   from ThermoScreening.thermo.api import xtb_thermo, xtb_cli_thermo
+
+   gas = xtb_thermo(molecule("H2O"))                       # tblite, gas phase
+   solv = xtb_cli_thermo(molecule("H2O"), solvent="water") # native xtb + ALPB
+
+Conformers, then screen the ensemble:
+
+.. code-block:: python
+
+   from ThermoScreening.thermo import generate_conformers, write_conformers, screen
+
+   conformers = generate_conformers("CCCCO", max_conformers=10)
+   write_conformers(conformers, "butanol_confs")
+   results = screen("butanol_confs", engine="xtb-cli")
+
+End-to-end example
+------------------
+
+The ``examples/`` directory in the repository contains a complete DFTB+
+thermochemistry input (``thermo.in``) together with the optimised geometry,
+frequencies and energy it consumes.


### PR DESCRIPTION
Resolves #32 — structured user + API documentation. (The issue's two notes were already partly met: DFTB+/Slater-Koster setup is documented in the README, and `examples/` has an end-to-end input; this adds the structured site around them.)

## What changed
- **`docs/`** — a Sphinx site that **builds cleanly (0 warnings)**:
  - `installation.rst` — pip vs. the `environment.yml` full stack, the backends table, and explicit DFTB+/Slater-Koster + GBSA setup via `thermo setup-dftb`.
  - `usage.rst` — all four CLI subcommands (**including `thermo screen`**, previously undocumented) + a Python quickstart (dftb+/xtb/xtb-cli/conformers) + a pointer to the `examples/` end-to-end input.
  - `configuration.rst` — reference for engines/parameter-sets, solvation, quasi-RRHO, spin/charge, temperature/pressure, `--resume`, and the screening input formats.
  - `api.rst` — autodoc of the public API (`dftbplus_thermo`, `xtb_thermo`, `xtb_cli_thermo`, `run_thermo`, `screen`, `generate_conformers`, `System`, `Thermo`, readers, backend setup).
  - `conf.py` — autodoc + napoleon + viewcode, `alabaster` theme (no extra deps beyond the existing `docs` extra), `tblite` mocked (lazy/optional import).
- **`.github/workflows/docs.yml`** — builds the docs on every push/PR so they can't rot.
- **README** — links the docs and how to build them.

## Verified
`python -m sphinx -b html docs docs/_build/html` → **build succeeded, 0 warnings**; autodoc imports the package and renders the API.

Closes #32. No source changes, so the test suite is unaffected (269 passed / 11 skipped).