### PR TITLE
Set up PyPI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish to PyPI
+
+# Publishes when a GitHub Release is published. The release tag (e.g. v0.1.0)
+# becomes the version via setuptools_scm. Uses PyPI Trusted Publishing (OIDC),
+# so no API token/secret is needed -- configure a trusted publisher for the
+# project on PyPI pointing at this repository and workflow.
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # OIDC token for Trusted Publishing
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # setuptools_scm needs the tags
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,15 @@ description = "A Python package for screening molecules for their thermochemical
 requires-python = ">=3.12"
 readme = "README.md"
 license = { file = "LICENSE" }
+keywords = ["thermochemistry", "DFTB+", "xTB", "screening", "computational chemistry"]
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)",
     "Operating System :: OS Independent",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Chemistry",
+    "Development Status :: 3 - Alpha",
 ]
 
 dependencies = [
@@ -30,6 +35,11 @@ dependencies = [
     "rdkit",
     "PQAnalysis >= 1.3.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/MolarVerse/ThermoScreening"
+Repository = "https://github.com/MolarVerse/ThermoScreening"
+Issues = "https://github.com/MolarVerse/ThermoScreening/issues"
 
 [project.optional-dependencies]
 test = [
@@ -45,7 +55,8 @@ docs = [
 ]
 
 [tool.setuptools.packages.find]
-exclude = ["external", "external.*", "tests", "tests.*"]
+# only ship the package itself (not docs/examples/benchmarks/tests/external)
+include = ["ThermoScreening", "ThermoScreening.*"]
 
 [tool.setuptools_scm]
 version_file = "ThermoScreening/__version__.py"


### PR DESCRIPTION
Sets up publishing to PyPI (the release step gated on the now-empty issue tracker).

## What changed
- **`pyproject.toml`**
  - **Packaging bug fix**: `packages.find` now `include`s only `ThermoScreening*`. The previous `exclude`-list let `docs/`, `examples/`, and `benchmarks/` leak into the wheel as top-level namespace packages (they'd pollute users' `site-packages`). The wheel now contains only `ThermoScreening/`.
  - Added `[project.urls]` (Homepage/Repository/Issues), `keywords`, and `Intended Audience :: Science/Research` + `Topic :: Scientific/Engineering :: Chemistry` + `Development Status :: 3 - Alpha` classifiers for a proper PyPI page.
- **`.github/workflows/publish.yml`** — builds sdist+wheel and publishes on a **GitHub Release** via **PyPI Trusted Publishing (OIDC)** — no API token/secret. The release tag becomes the version via `setuptools_scm`.

Verified locally: `python -m build` → clean sdist + wheel (only `ThermoScreening/`), `twine check` PASSED for both.

## To actually publish (your steps — I can't do these; they need PyPI access)
1. On **pypi.org** → the `thermoscreening` project → add a **Trusted Publisher** (or a "pending publisher" for the first upload): owner `MolarVerse`, repo `ThermoScreening`, workflow `publish.yml`.
2. **Create a GitHub Release** tagged `v0.1.0` — that triggers the workflow, which builds and publishes.

`thermoscreening` is available on PyPI. Note: `pip install thermoscreening` gets the Python package; the compiled backends still come from conda (`environment.yml`) — documented in the README/docs.