### PR TITLE
Add conda-forge recipes for ThermoScreening and PQAnalysis

### DIFF
--- a/conda-recipes/README.md
+++ b/conda-recipes/README.md
@@ -1,0 +1,68 @@
+# conda-forge recipes
+
+Draft [conda-forge](https://conda-forge.org/) recipes for distributing
+ThermoScreening (and its dependency PQAnalysis) through the `conda-forge`
+channel. They are kept here for reference and maintenance; the recipes that
+conda-forge actually builds live in per-package *feedstock* repositories created
+from [`conda-forge/staged-recipes`](https://github.com/conda-forge/staged-recipes).
+
+## Why two recipes
+
+`ThermoScreening` depends on `PQAnalysis`, which is **not yet on conda-forge**.
+conda-forge packages may only depend on other conda-forge packages, so
+`PQAnalysis` has to land first. Every other dependency (`numpy`, `scipy`,
+`pymatgen-core`, `beartype`, `ase`, `rdkit`, and PQAnalysis's own
+`multimethod`/`lark`/`tqdm`/`decorator`/`argcomplete`/`rich-argparse`) is
+already available on conda-forge.
+
+| Recipe | noarch? | Notes |
+|--------|---------|-------|
+| `pqanalysis/` | no | Ships a compiled Cython extension, so it builds per platform (needs a C compiler). |
+| `thermoscreening/` | yes | Pure Python. |
+
+## Submission order
+
+1. **PQAnalysis first.** Fork `conda-forge/staged-recipes`, copy
+   `pqanalysis/` into its `recipes/` directory, and open a PR. Once it is
+   merged, conda-forge's bot creates `PQAnalysis-feedstock` and publishes the
+   package (usually within an hour).
+2. **ThermoScreening second.** After `pqanalysis` is available on the
+   `conda-forge` channel, submit `thermoscreening/` the same way. Its
+   `pqanalysis >=1.3.0` run requirement will then resolve.
+
+staged-recipes can build sibling recipes in dependency order within a single
+PR, so submitting both at once can work — but the two-step order above is the
+simpler, lower-risk path and lets `pqanalysis` publish before `thermoscreening`
+is reviewed.
+
+## Before submitting
+
+- **Maintainer(s):** `extra.recipe-maintainers` lists `galjos`. Add any other
+  GitHub usernames who should co-maintain the feedstocks.
+- **Versions & hashes** are pinned to the current PyPI releases
+  (PQAnalysis 1.3.0, ThermoScreening 0.1.0). To refresh for a new release,
+  bump `version` and replace `sha256` with the sdist hash:
+
+  ```bash
+  # prints the sha256 of the PyPI source tarball
+  curl -sL https://pypi.org/pypi/ThermoScreening/json \
+    | python -c "import json,sys; d=json.load(sys.stdin); \
+        print(next(u['digests']['sha256'] for u in d['urls'] if u['packagetype']=='sdist'))"
+  ```
+
+  After the feedstocks exist, conda-forge's `regro-cf-autotick-bot` opens
+  version-bump PRs automatically, so this is mainly needed for the initial
+  submission.
+
+## Local check (optional)
+
+If you have `conda-build` installed you can lint/build a recipe before
+submitting:
+
+```bash
+conda build conda-recipes/pqanalysis
+conda build conda-recipes/thermoscreening -c conda-forge
+```
+
+See the conda-forge [contributing guide](https://conda-forge.org/docs/maintainer/adding_pkgs/)
+for the full staged-recipes workflow.

--- a/conda-recipes/pqanalysis/bld.bat
+++ b/conda-recipes/pqanalysis/bld.bat
@@ -1,0 +1,4 @@
+set SETUPTOOLS_SCM_PRETEND_VERSION=%PKG_VERSION%
+
+%PYTHON% -m pip install . -vv --no-deps --no-build-isolation
+if errorlevel 1 exit 1

--- a/conda-recipes/pqanalysis/build.sh
+++ b/conda-recipes/pqanalysis/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euxo pipefail
+
+# The PyPI sdist has no .git, so tell setuptools_scm the version explicitly.
+export SETUPTOOLS_SCM_PRETEND_VERSION="${PKG_VERSION}"
+
+$PYTHON -m pip install . -vv --no-deps --no-build-isolation

--- a/conda-recipes/pqanalysis/meta.yaml
+++ b/conda-recipes/pqanalysis/meta.yaml
@@ -1,0 +1,75 @@
+{% set name = "PQAnalysis" %}
+{% set version = "1.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0]|lower }}/{{ name|lower }}/{{ name|lower }}-{{ version }}.tar.gz
+  sha256: 6b7ecd3aeb553c8c8cdc12805f991145e956690d73a7eddd4f71481c519ddc3e
+
+build:
+  number: 0
+  # Not noarch: PQAnalysis ships a compiled Cython extension
+  # (PQAnalysis/io/traj_file/*.pyx), so it is built per platform. pip enforces
+  # Requires-Python >=3.12, so skip the older interpreters in the build matrix.
+  skip: true  # [py<312]
+  entry_points:
+    - pqanalysis = PQAnalysis.cli.main:main
+    - traj2box = PQAnalysis.cli.traj2box:main
+    - traj2extxyz = PQAnalysis.cli.traj2extxyz:main
+    - traj2qmcfc = PQAnalysis.cli.traj2qmcfc:main
+    - rst2xyz = PQAnalysis.cli.rst2xyz:main
+    - xyz2rst = PQAnalysis.cli.xyz2rst:main
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+  host:
+    - python
+    - pip
+    - setuptools >=70
+    - setuptools_scm >=8
+    - wheel
+    - cython >=3
+    - numpy
+  run:
+    - python
+    - numpy
+    - scipy
+    - beartype
+    - multimethod
+    - lark
+    - tqdm
+    - decorator
+    - argcomplete
+    - rich-argparse
+
+test:
+  imports:
+    - PQAnalysis
+    - PQAnalysis.io
+    # the compiled Cython extension; import fails if the C build is broken
+    - PQAnalysis.io.traj_file.process_lines
+  commands:
+    - pip check
+    - pqanalysis --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/MolarVerse/PQAnalysis
+  license: MIT
+  license_file: LICENSE
+  summary: A Python package for the post-processing and analysis of molecular dynamics simulations.
+  description: |
+    PQAnalysis reads, writes, and analyses molecular dynamics trajectories and
+    related data (coordinates, restart files, cells), with command-line tools
+    for common trajectory conversions.
+  dev_url: https://github.com/MolarVerse/PQAnalysis
+
+extra:
+  recipe-maintainers:
+    - galjos

--- a/conda-recipes/thermoscreening/meta.yaml
+++ b/conda-recipes/thermoscreening/meta.yaml
@@ -1,0 +1,65 @@
+{% set name = "ThermoScreening" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0]|lower }}/{{ name|lower }}/{{ name|lower }}-{{ version }}.tar.gz
+  sha256: bf4e0d8d962d849788b7ae3687ec0b4da8abc7300d09278173b674285cff77a1
+
+build:
+  number: 0
+  noarch: python
+  # The PyPI sdist has no .git, so pin the version for setuptools_scm.
+  script: |
+    export SETUPTOOLS_SCM_PRETEND_VERSION=${PKG_VERSION}
+    {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - thermo = ThermoScreening.cli.thermo:main
+
+requirements:
+  host:
+    - python >=3.12
+    - pip
+    - setuptools >=42
+    - setuptools_scm >=8
+    - wheel
+  run:
+    - python >=3.12
+    - numpy >=1.26
+    - scipy
+    - pymatgen-core >=2026.5.18
+    - beartype
+    - ase
+    - rdkit
+    # Requires the PQAnalysis feedstock (submit that recipe first).
+    - pqanalysis >=1.3.0
+
+test:
+  imports:
+    - ThermoScreening
+    - ThermoScreening.thermo
+  commands:
+    - pip check
+    - thermo --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/MolarVerse/ThermoScreening
+  license: LGPL-2.1-or-later
+  license_file: LICENSE
+  summary: Thermochemical property calculation and screening for molecular systems.
+  description: |
+    ThermoScreening calculates thermochemical properties for molecular systems
+    with DFTB+ and xTB backends. It provides conformer generation, batch
+    screening, and post-processing for reaction/redox free energies and
+    conformer-ensemble (Boltzmann) thermochemistry.
+  doc_url: https://molarverse.github.io/ThermoScreening/
+  dev_url: https://github.com/MolarVerse/ThermoScreening
+
+extra:
+  recipe-maintainers:
+    - galjos


### PR DESCRIPTION
## What

Draft [conda-forge](https://conda-forge.org/) recipes so the tool can be distributed on the `conda-forge` channel, kept in-repo under `conda-recipes/` for reference and maintenance.

- **`conda-recipes/pqanalysis/`** — the `PQAnalysis` dependency, which is on PyPI but **not** conda-forge and must land there first (conda-forge packages can only depend on conda-forge packages). It ships a compiled Cython extension, so it is a per-platform (non-noarch) recipe with `{{ compiler('c') }}` / `{{ stdlib('c') }}`, `build.sh` + `bld.bat`, and a `skip: true # [py<312]` (pip enforces `Requires-Python >=3.12` across the build matrix). The test imports the compiled `PQAnalysis.io.traj_file.process_lines` module.
- **`conda-recipes/thermoscreening/`** — the pure-Python `noarch: python` recipe.
- **`conda-recipes/README.md`** — submission order (PQAnalysis → ThermoScreening), maintainer notes, and the sha256/version-bump workflow.

## Verification

- Every other dependency (`numpy`, `scipy`, `pymatgen-core`, `beartype`, `ase`, `rdkit`, and PQAnalysis's `multimethod`/`lark`/`tqdm`/`decorator`/`argcomplete`/`rich-argparse`) is already on conda-forge.
- Both source URLs resolve and their `sha256` match the PyPI sdists; both sdists ship a root `LICENSE`.
- Both `meta.yaml` render to valid YAML with the conda jinja macros stubbed.
- Recipes reviewed against current staged-recipes conventions (SPDX license ids, numpy 2.0 ABI policy, `setuptools_scm` pretend-version for versionless sdists).

## Note

These are not built by this repo's CI — they get submitted to `conda-forge/staged-recipes`, where conda-forge's own CI builds them. This PR just versions the drafts. conda-forge maintainer review + feedstock creation happens externally.