### PR TITLE
Complete PQAnalysis recipe entry points for 1.3.0

### DIFF
--- a/conda-recipes/pqanalysis/meta.yaml
+++ b/conda-recipes/pqanalysis/meta.yaml
@@ -22,6 +22,13 @@ build:
     - traj2qmcfc = PQAnalysis.cli.traj2qmcfc:main
     - rst2xyz = PQAnalysis.cli.rst2xyz:main
     - xyz2rst = PQAnalysis.cli.xyz2rst:main
+    - continue_input = PQAnalysis.cli.continue_input:main
+    - rdf = PQAnalysis.cli.rdf:main
+    - add_molecules = PQAnalysis.cli.add_molecules:main
+    - activate_argcomplete = PQAnalysis.cli.activate_argcomplete:main
+    - build_nep_traj = PQAnalysis.cli.build_nep_traj:main
+    - xyz2gen = PQAnalysis.cli.xyz2gen:main
+    - gen2xyz = PQAnalysis.cli.gen2xyz:main
 
 requirements:
   build:


### PR DESCRIPTION
The `conda-recipes/pqanalysis/` recipe listed only 6 of the 13 console scripts that PQAnalysis 1.3.0 actually exposes (an earlier draft was truncated). Verified against the `v1.3.0` tag's `[project.scripts]`, this adds the missing entry points:

- `continue_input`, `rdf`, `add_molecules`, `activate_argcomplete`, `build_nep_traj`, `xyz2gen`, `gen2xyz`

The recipe passes `conda-smithy recipe-lint` ("in fine form"). Prep for the upcoming `conda-forge/staged-recipes` submission of PQAnalysis.