### PR TITLE
Use python_min pin in the thermoscreening recipe

### DIFF
--- a/conda-recipes/thermoscreening/meta.yaml
+++ b/conda-recipes/thermoscreening/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "ThermoScreening" %}
 {% set version = "0.1.0" %}
+{% set python_min = "3.12" %}
 
 package:
   name: {{ name|lower }}
@@ -21,20 +22,19 @@ build:
 
 requirements:
   host:
-    - python >=3.12
+    - python {{ python_min }}
     - pip
     - setuptools >=42
     - setuptools_scm >=8
     - wheel
   run:
-    - python >=3.12
+    - python >={{ python_min }}
     - numpy >=1.26
     - scipy
     - pymatgen-core >=2026.5.18
     - beartype
     - ase
     - rdkit
-    # Requires the PQAnalysis feedstock (submit that recipe first).
     - pqanalysis >=1.3.0
 
 test:
@@ -46,6 +46,7 @@ test:
     - thermo --help
   requires:
     - pip
+    - python {{ python_min }}
 
 about:
   home: https://github.com/MolarVerse/ThermoScreening


### PR DESCRIPTION
Syncs `conda-recipes/thermoscreening/meta.yaml` with the conda-forge submission: adopt the `noarch: python` `python_min` convention (`host: python {{ python_min }}`, `run: python >={{ python_min }}`, and `python {{ python_min }}` in `test.requires`, with `{% set python_min = "3.12" %}`).

This clears the conda-forge-linter's `noarch` hint on [staged-recipes#34095](https://github.com/conda-forge/staged-recipes/pull/34095) and keeps the reference recipe identical to the submitted one.