### PR TITLE
Give Thermo total_* accessors default units

### DIFF
--- a/ThermoScreening/thermo/thermo.py
+++ b/ThermoScreening/thermo/thermo.py
@@ -808,14 +808,15 @@ class Thermo:
         )
 
 
-    def total_energy(self, unit: str) -> float:
+    def total_energy(self, unit: str = "H") -> float:
         """
         Returns the total energy of the system based on the unit.
 
         Parameters
         ----------
         unit : str
-            The unit of the total energy.
+            The unit of the total energy (``"H"``, ``"kcal"`` or ``"cal"``).
+            Defaults to ``"H"`` (Hartree).
 
         Raises
         ------
@@ -836,14 +837,15 @@ class Thermo:
             return _real_scalar(self._total_energy)
         raise TSValueError("The unit is not supported.")
 
-    def total_enthalpy(self, unit: str) -> float:
+    def total_enthalpy(self, unit: str = "H") -> float:
         """
         Returns the total enthalpy of the system based on the unit.
 
         Parameters
         ----------
         unit : str
-            The unit of the total enthalpy.
+            The unit of the total enthalpy (``"H"``, ``"kcal"`` or ``"cal"``).
+            Defaults to ``"H"`` (Hartree).
 
         Raises
         ------
@@ -864,14 +866,15 @@ class Thermo:
             return _real_scalar(self._total_enthalpy)
         raise TSValueError("The unit is not supported.")
 
-    def total_entropy(self, unit: str) -> float:
+    def total_entropy(self, unit: str = "cal/(mol*K)") -> float:
         """
         Returns the total entropy of the system based on the unit.
 
         Parameters
         ----------
         unit : str
-            The unit of the total entropy.
+            The unit of the total entropy (``"cal/(mol*K)"`` or ``"H/T"``).
+            Defaults to ``"cal/(mol*K)"``.
 
         Raises
         ------
@@ -890,14 +893,15 @@ class Thermo:
             return _real_scalar(self._total_entropy)
         raise TSValueError("The unit is not supported.")
 
-    def total_gibbs_free_energy(self, unit: str) -> float:
+    def total_gibbs_free_energy(self, unit: str = "H") -> float:
         """
         Returns the total Gibbs free energy of the system based on the unit.
 
         Parameters
         ----------
         unit : str
-            The unit of the total Gibbs free energy.
+            The unit of the total Gibbs free energy (``"H"``, ``"kcal"`` or
+            ``"cal"``). Defaults to ``"H"`` (Hartree).
 
         Raises
         ------
@@ -918,7 +922,7 @@ class Thermo:
             return _real_scalar(self._total_gibbs_free_energy)
         raise TSValueError("The unit is not supported.")
 
-    def total_heat_capacity(self, unit: str) -> float:
+    def total_heat_capacity(self, unit: str = "cal/(mol*K)") -> float:
         """
         Returns the constant-volume (ideal-gas) heat capacity Cv of the system.
 
@@ -930,7 +934,8 @@ class Thermo:
         Parameters
         ----------
         unit : str
-            The unit of the total heat capacity.
+            The unit of the total heat capacity (``"cal/(mol*K)"`` or
+            ``"H/T"``). Defaults to ``"cal/(mol*K)"``.
 
         Raises
         ------

--- a/tests/thermo/test_thermo.py
+++ b/tests/thermo/test_thermo.py
@@ -71,6 +71,17 @@ def test_scalar_total_accessors_return_real_floats_for_all_units():
     assert thermo.electronic_energy() == 17.0
 
 
+def test_scalar_total_accessors_default_units():
+    thermo = _thermo_with_scalar_totals()
+
+    # energies default to Hartree, entropy/heat-capacity to cal/(mol*K)
+    assert thermo.total_energy() == thermo.total_energy("H") == 1.0
+    assert thermo.total_enthalpy() == thermo.total_enthalpy("H") == 4.0
+    assert thermo.total_entropy() == thermo.total_entropy("cal/(mol*K)") == 8.0
+    assert thermo.total_gibbs_free_energy() == thermo.total_gibbs_free_energy("H") == 9.0
+    assert thermo.total_heat_capacity() == thermo.total_heat_capacity("cal/(mol*K)") == 12.0
+
+
 @pytest.mark.parametrize(
     "method_name",
     [


### PR DESCRIPTION
The `total_*` accessors required an explicit `unit`, so the README's `thermo.total_gibbs_free_energy()` (no argument) raised `TypeError`.

Add sensible defaults: `total_energy`/`total_enthalpy`/`total_gibbs_free_energy` default to `"H"` (Hartree); `total_entropy`/`total_heat_capacity` to `"cal/(mol*K)"`. Existing explicit-unit calls are unaffected; the README example now works as written.

Tested (no-arg equals explicit default). Full patch coverage.

Closes #94