### PR TITLE
Import DFT Hessians/energies from ORCA .hess files

### DIFF
--- a/ThermoScreening/calculator/__init__.py
+++ b/ThermoScreening/calculator/__init__.py
@@ -1,3 +1,4 @@
 """Calculator backends for ThermoScreening."""
 
 from .dftbplus import Geoopt, Hessian, Modes
+from .orca import read_orca_hess

--- a/ThermoScreening/calculator/orca.py
+++ b/ThermoScreening/calculator/orca.py
@@ -1,0 +1,112 @@
+"""Reader for ORCA Hessian (``.hess``) files.
+
+Lets ThermoScreening consume DFT-quality geometries, vibrational frequencies and
+energies from an ORCA frequency calculation, so the RRHO thermochemistry is
+computed on accurate data instead of a semiempirical Hamiltonian.
+"""
+
+import numpy as np
+from ase import Atoms
+from ase.units import Bohr
+
+from ..exceptions import TSValueError
+
+
+def _read_block(lines, name):
+    """
+    Return the lines of the ``$name`` block (between its tag and the next ``$``
+    tag or end of file), or ``None`` if the block is absent.
+    """
+    tag = f"${name}"
+    for index, line in enumerate(lines):
+        if line.strip() == tag:
+            block = []
+            for following in lines[index + 1:]:
+                if following.lstrip().startswith("$"):
+                    break
+                block.append(following)
+            return block
+    return None
+
+
+def read_orca_hess(path):
+    """
+    Read geometry, vibrational frequencies and energy from an ORCA ``.hess`` file.
+
+    Parameters
+    ----------
+    path : str
+        Path to an ORCA ``.hess`` file (from an ORCA frequency calculation).
+
+    Returns
+    -------
+    atoms : ase.Atoms
+        The geometry, converted from Bohr to Angstrom.
+    frequencies : np.ndarray
+        The vibrational frequencies in cm^-1, including the near-zero
+        translational/rotational modes as ORCA writes them.
+    energy : float or None
+        The electronic energy in Hartree from the ``$act_energy`` block, or
+        ``None`` if the file has no such block.
+
+    Raises
+    ------
+    TSValueError
+        If the required ``$atoms`` or ``$vibrational_frequencies`` block is
+        missing or malformed.
+    """
+    with open(path, "r", encoding="utf-8") as handle:
+        lines = handle.readlines()
+
+    atoms_block = _read_block(lines, "atoms")
+    if atoms_block is None:
+        raise TSValueError(f"No $atoms block in ORCA hess file '{path}'.")
+    freq_block = _read_block(lines, "vibrational_frequencies")
+    if freq_block is None:
+        raise TSValueError(
+            f"No $vibrational_frequencies block in ORCA hess file '{path}'."
+        )
+
+    # $atoms: <natoms>, then per atom "<symbol> <mass> <x> <y> <z>" (Bohr)
+    atom_lines = [line for line in atoms_block if line.strip()]
+    try:
+        n_atoms = int(atom_lines[0].split()[0])
+        symbols, positions = [], []
+        for line in atom_lines[1:1 + n_atoms]:
+            tokens = line.split()
+            symbols.append(tokens[0])
+            positions.append([float(tokens[2]), float(tokens[3]), float(tokens[4])])
+    except (IndexError, ValueError) as exc:
+        raise TSValueError(f"Malformed $atoms block in '{path}': {exc}")
+    if len(symbols) != n_atoms:
+        raise TSValueError(
+            f"$atoms block in '{path}' declares {n_atoms} atoms but lists {len(symbols)}."
+        )
+    atoms = Atoms(symbols=symbols, positions=np.array(positions) * Bohr)
+
+    # $vibrational_frequencies: <count>, then "<index> <frequency>" (cm^-1)
+    freq_lines = [line for line in freq_block if line.strip()]
+    try:
+        n_freq = int(freq_lines[0].split()[0])
+        frequencies = np.array(
+            [float(line.split()[1]) for line in freq_lines[1:1 + n_freq]]
+        )
+    except (IndexError, ValueError) as exc:
+        raise TSValueError(
+            f"Malformed $vibrational_frequencies block in '{path}': {exc}"
+        )
+    if len(frequencies) != n_freq:
+        raise TSValueError(
+            f"$vibrational_frequencies block in '{path}' declares {n_freq} entries "
+            f"but lists {len(frequencies)}."
+        )
+
+    energy = None
+    energy_block = _read_block(lines, "act_energy")
+    if energy_block is not None:
+        for line in energy_block:
+            if line.strip():
+                energy = float(line.split()[0])
+                break
+
+    return atoms, frequencies, energy

--- a/ThermoScreening/calculator/orca.py
+++ b/ThermoScreening/calculator/orca.py
@@ -49,6 +49,11 @@ def read_orca_hess(path):
         The electronic energy in Hartree from the ``$act_energy`` block, or
         ``None`` if the file has no such block.
 
+    Notes
+    -----
+    The per-atom mass column is not used; ASE's standard isotope masses are used
+    for the rotational/translational terms (as with the other engines).
+
     Raises
     ------
     TSValueError

--- a/ThermoScreening/thermo/api.py
+++ b/ThermoScreening/thermo/api.py
@@ -19,6 +19,7 @@ from .thermo import Thermo
 from .atoms import Atom
 from ..calculator import Geoopt, Hessian, Modes
 from ..calculator.dftbplus import _spin_kwargs, _solvation_kwargs, _dispersion_kwargs, SPIN_CONSTANTS_3OB
+from ..calculator.orca import read_orca_hess
 from ..calculator.xtb import optimise_and_frequencies, xtb_calculator
 from ..calculator.xtb_cli import run_xtb
 
@@ -427,6 +428,75 @@ def run_thermo(
     thermo_setup.run()
 
     return thermo_setup
+
+
+def orca_thermo(
+    hess_file,
+    energy=None,
+    temperature=298.15,
+    pressure=101325,
+    charge=0.0,
+    spin=None,
+    quasi_rrho=False,
+):
+    """
+    Run the thermochemistry from an ORCA ``.hess`` file (DFT-quality data).
+
+    Reads the geometry, vibrational frequencies and energy from the ORCA
+    frequency output and evaluates the RRHO thermochemistry on them, so the
+    absolute energetics (e.g. reaction/redox free energies) are DFT-accurate
+    rather than semiempirical.
+
+    Parameters
+    ----------
+    hess_file : str
+        Path to an ORCA ``.hess`` file.
+    energy : float, optional
+        Electronic energy in Hartree. Defaults to the file's ``$act_energy``;
+        pass this to override it (or when the file has no energy block).
+    temperature : float
+        Temperature in K. Default 298.15.
+    pressure : float
+        Pressure in Pa. Default 101325.
+    charge : float
+        System charge. Default 0.0.
+    spin : float, optional
+        Spin quantum number S. Defaults to the minimum-spin electron-count guess.
+    quasi_rrho : bool
+        If True, use Grimme's quasi-RRHO vibrational entropy. Default False.
+
+    Returns
+    -------
+    Thermo
+        The thermo calculation object.
+
+    Raises
+    ------
+    TSValueError
+        If no energy is available (no ``$act_energy`` block and no ``energy``).
+    """
+    atoms, frequencies, file_energy = read_orca_hess(hess_file)
+    if energy is None:
+        energy = file_energy
+    if energy is None:
+        raise TSValueError(
+            f"No energy for '{hess_file}': it has no $act_energy block, so pass "
+            "energy=... explicitly."
+        )
+
+    # The RRHO treatment is engine-agnostic (frequencies are cm^-1 and the energy
+    # is Hartree, as the DFTB+ path also provides); reuse that code path.
+    return run_thermo(
+        vibrational_frequencies=frequencies,
+        atoms=atoms,
+        energy=energy,
+        temperature=temperature,
+        pressure=pressure,
+        charge=charge,
+        spin=spin,
+        engine="dftb+",
+        quasi_rrho=quasi_rrho,
+    )
 
 
 def execute(input_file: str) -> Thermo:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,6 +7,7 @@ High-level pipeline
 .. autofunction:: ThermoScreening.thermo.api.dftbplus_thermo
 .. autofunction:: ThermoScreening.thermo.api.xtb_thermo
 .. autofunction:: ThermoScreening.thermo.api.xtb_cli_thermo
+.. autofunction:: ThermoScreening.thermo.api.orca_thermo
 .. autofunction:: ThermoScreening.thermo.api.run_thermo
 .. autofunction:: ThermoScreening.thermo.api.execute
 
@@ -54,6 +55,7 @@ Coordinate and frequency readers
 .. autofunction:: ThermoScreening.thermo.api.read_gen
 .. autofunction:: ThermoScreening.thermo.api.read_coord
 .. autofunction:: ThermoScreening.thermo.api.read_vibrational
+.. autofunction:: ThermoScreening.calculator.orca.read_orca_hess
 
 Backend setup
 -------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -101,6 +101,26 @@ The ensemble free energy lies at or below the lowest conformer's by the mixing
 (conformational) entropy; use ``lowest_gibbs`` when you instead want the single
 dominant structure to carry forward (e.g. into :func:`reaction_free_energy`).
 
+DFT-quality thermochemistry (ORCA)
+----------------------------------
+
+GFN-xTB/DFTB absolute energies are semiempirical. To get DFT-accurate
+thermochemistry (e.g. for reliable reaction/redox free energies), feed an ORCA
+frequency calculation's ``.hess`` file straight in:
+
+.. code-block:: python
+
+   from ThermoScreening.thermo.api import orca_thermo
+   from ThermoScreening.thermo import reduction_potential
+
+   ox  = orca_thermo("oxidized.hess")   # geometry, frequencies and energy read
+   red = orca_thermo("reduced.hess")    # from the ORCA $act_energy block
+   E = reduction_potential(ox, red)     # now on DFT energetics
+
+Pass ``energy=`` to override the file's ``$act_energy`` (e.g. a higher-level
+single-point). ``read_orca_hess`` exposes the parsed geometry/frequencies/energy
+directly if you need them.
+
 Temperature scans
 -----------------
 

--- a/tests/calculator/test_orca.py
+++ b/tests/calculator/test_orca.py
@@ -1,0 +1,90 @@
+import math
+
+import pytest
+from ase.units import Bohr
+
+from ThermoScreening.calculator.orca import read_orca_hess
+from ThermoScreening.thermo.api import orca_thermo
+from ThermoScreening.exceptions import TSValueError
+
+# a minimal water ORCA .hess (coordinates in Bohr, frequencies in cm^-1)
+_HESS = """\
+$orca_hessian_file
+
+$act_energy
+     -76.400000
+
+$vibrational_frequencies
+9
+  0     0.000000
+  1     0.000000
+  2     0.000000
+  3     0.000000
+  4     0.000000
+  5     0.000000
+  6  1600.000000
+  7  3700.000000
+  8  3800.000000
+
+$atoms
+3
+O    15.999000    0.000000    0.000000    0.221722
+H     1.008000    0.000000    1.430901   -0.886569
+H     1.008000    0.000000   -1.430901   -0.886569
+
+$end
+"""
+
+
+def _write_hess(tmp_path, text=_HESS, name="water.hess"):
+    path = tmp_path / name
+    path.write_text(text, encoding="utf-8")
+    return str(path)
+
+
+def test_read_orca_hess_geometry_frequencies_energy(tmp_path):
+    atoms, freqs, energy = read_orca_hess(_write_hess(tmp_path))
+
+    assert list(atoms.get_chemical_symbols()) == ["O", "H", "H"]
+    # coordinates converted Bohr -> Angstrom
+    assert atoms.positions[0, 2] == pytest.approx(0.221722 * Bohr)
+    assert atoms.positions[1, 1] == pytest.approx(1.430901 * Bohr)
+    assert len(freqs) == 9
+    assert list(freqs[-3:]) == [1600.0, 3700.0, 3800.0]
+    assert energy == pytest.approx(-76.4)
+
+
+def test_read_orca_hess_missing_atoms(tmp_path):
+    path = _write_hess(tmp_path, "$vibrational_frequencies\n1\n0 0.0\n$end\n", "b.hess")
+    with pytest.raises(TSValueError, match=r"No \$atoms block"):
+        read_orca_hess(path)
+
+
+def test_read_orca_hess_missing_frequencies(tmp_path):
+    path = _write_hess(tmp_path, "$atoms\n1\nH 1.008 0 0 0\n$end\n", "b.hess")
+    with pytest.raises(TSValueError, match=r"No \$vibrational_frequencies block"):
+        read_orca_hess(path)
+
+
+def test_read_orca_hess_malformed_atom_count(tmp_path):
+    text = _HESS.replace("$atoms\n3\n", "$atoms\n5\n")  # declares 5, lists 3
+    with pytest.raises(TSValueError, match="declares 5 atoms"):
+        read_orca_hess(_write_hess(tmp_path, text, "b.hess"))
+
+
+def test_orca_thermo_uses_file_energy(tmp_path):
+    thermo = orca_thermo(_write_hess(tmp_path))
+    assert thermo.electronic_energy() == pytest.approx(-76.4)
+    assert math.isfinite(thermo.total_EeGtot())
+
+
+def test_orca_thermo_energy_override(tmp_path):
+    thermo = orca_thermo(_write_hess(tmp_path), energy=-77.0)
+    assert thermo.electronic_energy() == pytest.approx(-77.0)
+
+
+def test_orca_thermo_requires_energy(tmp_path):
+    # remove the $act_energy block (disable the tag) and pass no energy
+    text = _HESS.replace("$act_energy", "$x_act_energy")
+    with pytest.raises(TSValueError, match="No energy"):
+        orca_thermo(_write_hess(tmp_path, text, "noenergy.hess"))

--- a/tests/calculator/test_orca.py
+++ b/tests/calculator/test_orca.py
@@ -83,6 +83,40 @@ def test_orca_thermo_energy_override(tmp_path):
     assert thermo.electronic_energy() == pytest.approx(-77.0)
 
 
+_CO2_HESS = """\
+$act_energy
+    -188.500000
+
+$vibrational_frequencies
+9
+  0     0.000000
+  1     0.000000
+  2     0.000000
+  3     0.000000
+  4     0.000000
+  5   667.000000
+  6   667.000000
+  7  1333.000000
+  8  2349.000000
+
+$atoms
+3
+C    12.011000    0.000000    0.000000    0.000000
+O    15.999000    0.000000    0.000000    2.196000
+O    15.999000    0.000000    0.000000   -2.196000
+
+$end
+"""
+
+
+def test_orca_thermo_linear_molecule(tmp_path):
+    # CO2 is linear -> 5 zero modes, dof = 3N-5 = 4; exercises the
+    # order-sensitive frequency_dof / linear-rotor path end to end
+    thermo = orca_thermo(_write_hess(tmp_path, _CO2_HESS, "co2.hess"))
+    assert thermo.electronic_energy() == pytest.approx(-188.5)
+    assert math.isfinite(thermo.total_EeGtot())
+
+
 def test_orca_thermo_requires_energy(tmp_path):
     # remove the $act_energy block (disable the tag) and pass no energy
     text = _HESS.replace("$act_energy", "$x_act_energy")

--- a/tests/calculator/test_orca.py
+++ b/tests/calculator/test_orca.py
@@ -72,6 +72,33 @@ def test_read_orca_hess_malformed_atom_count(tmp_path):
         read_orca_hess(_write_hess(tmp_path, text, "b.hess"))
 
 
+def test_read_orca_hess_malformed_atom_coordinate(tmp_path):
+    text = (
+        "$atoms\n1\nO 15.999 notanumber 0.0 0.0\n"
+        "$vibrational_frequencies\n1\n0 0.0\n$end\n"
+    )
+    with pytest.raises(TSValueError, match=r"Malformed \$atoms block"):
+        read_orca_hess(_write_hess(tmp_path, text, "b.hess"))
+
+
+def test_read_orca_hess_malformed_frequency(tmp_path):
+    text = (
+        "$atoms\n1\nH 1.008 0.0 0.0 0.0\n"
+        "$vibrational_frequencies\n1\n0 notanumber\n$end\n"
+    )
+    with pytest.raises(TSValueError, match=r"Malformed \$vibrational_frequencies block"):
+        read_orca_hess(_write_hess(tmp_path, text, "b.hess"))
+
+
+def test_read_orca_hess_frequency_count_mismatch(tmp_path):
+    text = (
+        "$atoms\n1\nH 1.008 0.0 0.0 0.0\n"
+        "$vibrational_frequencies\n5\n0 0.0\n$end\n"  # declares 5, lists 1
+    )
+    with pytest.raises(TSValueError, match="declares 5 entries"):
+        read_orca_hess(_write_hess(tmp_path, text, "b.hess"))
+
+
 def test_orca_thermo_uses_file_energy(tmp_path):
     thermo = orca_thermo(_write_hess(tmp_path))
     assert thermo.electronic_energy() == pytest.approx(-76.4)


### PR DESCRIPTION
GFN-xTB/DFTB give poor absolute energies (and redox). This lets ThermoScreening consume DFT-quality data from an ORCA frequency calculation.

- **`read_orca_hess(path)`** parses the `$atoms` (geometry, Bohr → Angstrom via `ase.units.Bohr`), `$vibrational_frequencies` (cm⁻¹) and `$act_energy` (Hartree) blocks, returning `(ase.Atoms, frequencies, energy)`.
- **`orca_thermo(hess_file, energy=None, ...)`** reads the file and runs the RRHO thermochemistry through `run_thermo` (the treatment is engine-agnostic: frequencies cm⁻¹, energy Hartree). `energy` defaults to the file's `$act_energy` and is overridable; a clear error if neither is available.

So `reduction_potential(orca_thermo("ox.hess"), orca_thermo("red.hess"))` gives redox on DFT energetics — the accuracy GFN2 couldn't provide.

Tested with a synthetic water `.hess`: geometry/frequency/energy parsing (+ Bohr conversion), missing/malformed-block errors, energy-from-file / override / required, and an end-to-end `orca_thermo` run. Docs + full patch coverage.

Closes #98