### PR TITLE
Redesign the documentation with the Furo theme

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,17 @@
+/* Small, tasteful touches on top of Furo's defaults. */
+
+/* A gentle hover lift on the feature cards (sphinx-design) on the landing page. */
+.sd-card {
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.sd-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
+}
+
+/* Slightly tint inline code in prose so it reads as "code" without shouting. */
+.content p code.literal,
+.content li code.literal {
+  background: var(--color-code-background);
+  border-radius: 0.2em;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,9 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
+    "sphinx_copybutton",
+    "sphinx_design",
 ]
 
 autodoc_typehints = "description"
@@ -30,11 +33,60 @@ napoleon_google_docstring = False
 # docs builder.
 autodoc_mock_imports = ["tblite"]
 
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    # ASE's docs site does not currently publish a working objects.inv, so it
+    # is omitted here rather than shipping a permanent build warning.
+}
+
+# Copy-button: strip the leading '$ '/'>>> ' prompt so only the command is
+# copied, and don't try to copy continuation/output lines.
+copybutton_prompt_text = r">>> |\.\.\. |\$ "
+copybutton_prompt_is_regexp = True
+
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
-html_theme = "alabaster"
-html_static_path = []
+html_theme = "furo"
+html_title = "ThermoScreening"
+html_static_path = ["_static"]
+html_css_files = ["custom.css"]
+
+html_theme_options = {
+    "sidebar_hide_name": False,
+    "light_css_variables": {
+        "color-brand-primary": "#1f6f5c",
+        "color-brand-content": "#1f6f5c",
+    },
+    "dark_css_variables": {
+        "color-brand-primary": "#5fd8bb",
+        "color-brand-content": "#5fd8bb",
+    },
+    "source_repository": "https://github.com/MolarVerse/ThermoScreening/",
+    "source_branch": "main",
+    "source_directory": "docs/",
+    "footer_icons": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/MolarVerse/ThermoScreening",
+            "html": (
+                '<svg stroke="currentColor" fill="currentColor" stroke-width="0" '
+                'viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 0C3.58 0 0 '
+                '3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01'
+                '-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13'
+                '-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 '
+                '2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31'
+                '-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 '
+                '1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 '
+                '1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 '
+                '3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55'
+                '.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>'
+            ),
+            "class": "",
+        },
+    ],
+}
 
 # Canonical location of the published documentation (GitHub Pages).
 html_baseurl = "https://molarverse.github.io/ThermoScreening/"

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -4,16 +4,22 @@ Configuration
 Engines and methods
 -------------------
 
-+---------------+----------------------------+-------------------------------------------+
-| ``engine``    | Backend                    | Notes                                     |
-+===============+============================+===========================================+
-| ``dftb+``     | DFTB+                      | ``--parameter-set 3ob`` (DFTB3) or        |
-| (default)     |                            | ``mio`` (DFTB2); needs ``DFTB_PREFIX``    |
-+---------------+----------------------------+-------------------------------------------+
-| ``xtb``       | GFN-xTB via tblite         | in-process, gas phase only                |
-+---------------+----------------------------+-------------------------------------------+
-| ``xtb-cli``   | native ``xtb`` binary      | open-shell + charge + implicit solvation  |
-+---------------+----------------------------+-------------------------------------------+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 30 55
+
+   * - ``engine``
+     - Backend
+     - Notes
+   * - ``dftb+`` (default)
+     - DFTB+
+     - ``--parameter-set 3ob`` (DFTB3) or ``mio`` (DFTB2); needs ``DFTB_PREFIX``
+   * - ``xtb``
+     - GFN-xTB via tblite
+     - in-process, gas phase only
+   * - ``xtb-cli``
+     - native ``xtb`` binary
+     - open-shell + charge + implicit solvation
 
 For the xtb engines, ``--method`` selects ``GFN2-xTB`` (default) or ``GFN1-xTB``.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,27 +1,107 @@
 ThermoScreening
 ===============
 
-ThermoScreening computes molecular thermochemistry and screens sets of molecules.
-It drives DFTB+ and GFN-xTB, runs geometry optimisation, Hessian and normal-mode
-analysis, and evaluates the ideal-gas thermochemistry (entropy, enthalpy, Gibbs
-free energy, heat capacity), with implicit solvation, quasi-RRHO, and conformer
-generation.
+.. image:: https://img.shields.io/pypi/v/thermoscreening.svg
+   :target: https://pypi.org/project/thermoscreening/
+   :alt: PyPI version
+
+.. image:: https://img.shields.io/pypi/pyversions/thermoscreening.svg
+   :target: https://pypi.org/project/thermoscreening/
+   :alt: Supported Python versions
+
+.. image:: https://img.shields.io/pypi/l/thermoscreening.svg
+   :target: https://github.com/MolarVerse/ThermoScreening/blob/main/LICENSE
+   :alt: License
+
+.. image:: https://github.com/MolarVerse/ThermoScreening/actions/workflows/python-app.yml/badge.svg
+   :target: https://github.com/MolarVerse/ThermoScreening/actions/workflows/python-app.yml
+   :alt: Build status
+
+.. image:: https://codecov.io/gh/MolarVerse/ThermoScreening/graph/badge.svg?token=KhrG0zVZmS
+   :target: https://codecov.io/gh/MolarVerse/ThermoScreening
+   :alt: Code coverage
+
+ThermoScreening computes molecular **thermochemistry** and screens sets of
+molecules. It drives DFTB+ and GFN-xTB (or imports DFT results from ORCA,
+Gaussian, Turbomole and PySCF), runs geometry optimisation, Hessian and
+normal-mode analysis, and evaluates the ideal-gas thermochemistry --
+entropy, enthalpy, Gibbs free energy, heat capacity -- with implicit
+solvation, quasi-RRHO, conformer ensembles, reaction/redox free energies,
+and transition-state kinetics.
+
+.. code-block:: python
+
+   from ase.build import molecule
+   from ThermoScreening.thermo.api import dftbplus_thermo
+   from ThermoScreening.calculator.dftbplus import dftb_3ob_parameters
+
+   thermo = dftbplus_thermo(molecule("H2O"), **dftb_3ob_parameters)
+   print(thermo.total_entropy("cal/(mol*K)"))   # ~45 cal/mol/K
+   print(thermo.total_gibbs_free_energy("H"))   # Hartree
+
+.. code-block:: bash
+
+   $ thermo screen molecules/ --parameter-set 3ob --solvent water --quasi-rrho --jobs 4
+
+New to ThermoScreening? Start with :doc:`installation` and :doc:`usage`.
 
 Features
 --------
 
-- **Engines**: DFTB+ (3ob / mio parameter sets), GFN-xTB via tblite
-  (``--engine xtb``), and the native ``xtb`` binary (``--engine xtb-cli``,
-  which adds implicit solvation of charged radicals).
-- **Thermochemistry** validated against ASE ``IdealGasThermo`` and native xtb.
-- **Implicit solvation** (GBSA/ALPB), **spin polarisation** for open-shell
-  species, and **Grimme quasi-RRHO** vibrational entropy.
-- **Batch screening** with per-molecule error isolation and ``--resume``.
-- **Conformer generation** from SMILES (RDKit ETKDG).
+.. grid:: 1 2 2 3
+   :gutter: 3
+
+   .. grid-item-card:: :octicon:`cpu` Engines
+      :link: configuration
+      :link-type: doc
+
+      DFTB+ (3ob / mio), GFN-xTB via tblite, and the native ``xtb`` binary
+      (open-shell radicals, charge, implicit solvation).
+
+      Or import DFT-quality results from **ORCA**, **Gaussian**,
+      **Turbomole** (via cclib) and **PySCF**.
+
+   .. grid-item-card:: :octicon:`beaker` Thermochemistry
+      :link: usage
+      :link-type: doc
+
+      Entropy, enthalpy, Gibbs free energy and heat capacity, validated
+      against ASE ``IdealGasThermo`` and native xtb. GBSA/ALPB implicit
+      solvation, spin polarisation, and Grimme's quasi-RRHO entropy.
+
+   .. grid-item-card:: :octicon:`git-branch` Reactions & redox
+      :link: usage
+      :link-type: doc
+
+      Reaction free energies and one-electron reduction potentials
+      (vs. SHE or a calibrated reference) from any two ``Thermo`` objects.
+
+   .. grid-item-card:: :octicon:`flame` Kinetics
+      :link: usage
+      :link-type: doc
+
+      Transition-state thermochemistry, Eyring rate constants, and a
+      Wigner tunneling correction from a saddle point's imaginary mode.
+
+   .. grid-item-card:: :octicon:`list-unordered` Batch screening
+      :link: usage
+      :link-type: doc
+
+      Screen a directory or CSV manifest in parallel (``--jobs``), with
+      per-molecule error isolation, ``--resume``, and ranking by Gibbs
+      free energy.
+
+   .. grid-item-card:: :octicon:`versions` Conformers & ensembles
+      :link: usage
+      :link-type: doc
+
+      Generate conformers from SMILES (RDKit ETKDG) and combine them into
+      Boltzmann-weighted ensemble thermochemistry.
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents
+   :hidden:
 
    installation
    usage

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -29,17 +29,22 @@ After this, ``thermo doctor`` should report every backend as found.
 Backends
 --------
 
-+-------------------+------------------------------------------+--------------------------------------------+
-| Backend           | Needed for                               | Install                                    |
-+===================+==========================================+============================================+
-| ``dftb+``,        | the DFTB+ engine                         | ``conda install -c conda-forge dftbplus``  |
-| ``modes``         |                                          |                                            |
-+-------------------+------------------------------------------+--------------------------------------------+
-| ``xtb``           | ``--engine xtb-cli`` (native xtb)        | ``conda install -c conda-forge xtb``       |
-+-------------------+------------------------------------------+--------------------------------------------+
-| ``tblite``        | ``--engine xtb`` (in-process GFN-xTB)    | ``conda install -c conda-forge             |
-|                   |                                          | tblite-python``                            |
-+-------------------+------------------------------------------+--------------------------------------------+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 35 45
+
+   * - Backend
+     - Needed for
+     - Install
+   * - ``dftb+``, ``modes``
+     - the DFTB+ engine
+     - ``conda install -c conda-forge dftbplus``
+   * - ``xtb``
+     - ``--engine xtb-cli`` (native xtb)
+     - ``conda install -c conda-forge xtb``
+   * - ``tblite``
+     - ``--engine xtb`` (in-process GFN-xTB)
+     - ``conda install -c conda-forge tblite-python``
 
 DFTB+ and Slater-Koster setup
 -----------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ lint = [
 ]
 docs = [
     "sphinx",
+    "furo",
+    "sphinx-copybutton",
+    "sphinx-design",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
The docs used Sphinx's default `alabaster` theme, which looks dated and plain. This switches to **Furo** (clean, modern, zero-config light/dark mode) plus `sphinx-copybutton` and `sphinx-design`, and refreshes the landing page.

## Theme
- `html_theme = "furo"`, a brand accent color (teal, light + dark variants), a GitHub footer icon, `sphinx-copybutton` (copy-to-clipboard on every code block), and `intersphinx` to Python/numpy docs.
- All new deps are added to the `docs` extra only — no runtime/core impact.

## Landing page (`index.rst`)
Rewritten: PyPI/Python-version/license/build/coverage badges, a verified quick-start snippet (pulled from `usage.rst`, not invented), and a `sphinx-design` feature-card grid. The old landing page only described the original DFTB+/xtb feature set — the grid now also covers reactions/redox, transition-state kinetics, and the ORCA/cclib/PySCF QM imports built this session, none of which were mentioned before.

## Tables
`installation.rst` and `configuration.rst` had hand-written ASCII grid tables that wrapped awkwardly (e.g. `tblite-python` split mid-word across lines). Converted to `list-table` directives — cleaner source and more consistent rendering.

## Verification
Built locally and visually reviewed every page (landing, API reference, usage, configuration) in **both light and dark mode** via a local preview server + browser screenshots — not just "the build succeeded." Zero Sphinx warnings (also fixed a pre-existing broken `ase` intersphinx inventory URL that was about to start warning). Full test suite passes (this PR only touches `docs/` and the `docs` extra in `pyproject.toml`).