### PR TITLE
Wrap cclib parser crashes into a clean TSValueError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ cover/
 
 # Django stuff:
 *.log
+# ... except real QM-program logfiles kept as test fixtures.
+!tests/data/**/*.log
 local_settings.py
 db.sqlite3
 db.sqlite3-journal

--- a/ThermoScreening/calculator/qm.py
+++ b/ThermoScreening/calculator/qm.py
@@ -104,12 +104,23 @@ def read_cclib(path):
     Raises
     ------
     TSValueError
-        If cclib is not installed, the file(s) cannot be parsed, or there are no
-        vibrational frequencies.
+        If cclib is not installed, the file(s) cannot be parsed (including a
+        parser crash on an unusual output format, wrapped from cclib), or there
+        are no vibrational frequencies.
     """
     cclib = _import_cclib()
 
-    data = cclib.io.ccread(_normalize_source(path))
+    try:
+        data = cclib.io.ccread(_normalize_source(path))
+    except Exception as exc:
+        # cclib's parsers are format/version-sensitive and can raise on an
+        # output format they don't fully handle (seen on real Gaussian 16 logs
+        # with cclib 1.8.1); surface that as our own exception type instead of
+        # letting an arbitrary cclib-internal exception escape uncontrolled.
+        raise TSValueError(
+            f"cclib raised {type(exc).__name__} while parsing "
+            f"'{_describe_source(path)}': {exc}"
+        ) from exc
     if data is None:
         raise TSValueError(f"cclib could not parse '{_describe_source(path)}' as a QM output.")
     if getattr(data, "vibfreqs", None) is None or not len(data.vibfreqs):

--- a/tests/calculator/test_qm.py
+++ b/tests/calculator/test_qm.py
@@ -25,6 +25,10 @@ _REAL_TURBOMOLE_FILES = sorted(
     if p.suffix != ".md"
 )
 
+_GAUSSIAN_DATA_DIR = Path(__file__).resolve().parents[1] / "data" / "calculator" / "gaussian"
+_REAL_GAUSSIAN_WATER = str(_GAUSSIAN_DATA_DIR / "water_neutral_opt_freq.out")
+_REAL_GAUSSIAN_UNPARSEABLE = str(_GAUSSIAN_DATA_DIR / "mp2_avdz_freq_tight.log")
+
 # water: geometry (Angstrom), three real modes, SCF energy in eV (~ -76.4 Ha)
 _WATER = dict(
     atomnos=np.array([8, 1, 1]),
@@ -187,3 +191,46 @@ def test_cclib_thermo_real_turbomole_output():
     assert thermo.electronic_energy() == pytest.approx(-951.0820621320888)
     assert math.isfinite(thermo.total_EeGtot())
     assert thermo.total_entropy("cal/(mol*K)") > 0
+
+
+# --- real Gaussian 16 output --- #
+#
+# See tests/data/calculator/gaussian/README.md for provenance.
+
+
+def test_read_cclib_real_gaussian_output():
+    atoms, freqs, energy = read_cclib(_REAL_GAUSSIAN_WATER)
+
+    assert list(atoms.get_chemical_symbols()) == ["O", "H", "H"]
+    assert list(freqs) == pytest.approx([2169.7613, 4141.3837, 4392.5759])
+    assert energy == pytest.approx(-74.96589788571758)
+
+
+def test_cclib_thermo_real_gaussian_output():
+    thermo = cclib_thermo(_REAL_GAUSSIAN_WATER)
+
+    assert thermo.electronic_energy() == pytest.approx(-74.96589788571758)
+    # gas-phase water's experimental standard entropy is ~45 cal/(mol K)
+    assert thermo.total_entropy("cal/(mol*K)") == pytest.approx(45.0, abs=2.0)
+    assert math.isfinite(thermo.total_EeGtot())
+
+
+def test_read_cclib_wraps_a_real_cclib_parser_crash():
+    # this real Gaussian 16 file's "Leave Link" timing line crashes cclib
+    # 1.8.1's own Gaussian parser with an unhandled ValueError (confirmed:
+    # still the latest cclib release at the time this test was written) --
+    # that must not leak out of read_cclib as a raw, arbitrary exception
+    with pytest.raises(TSValueError, match="cclib raised"):
+        read_cclib(_REAL_GAUSSIAN_UNPARSEABLE)
+
+
+def test_read_cclib_wraps_any_ccread_exception(monkeypatch):
+    # a cclib-version-independent guard for the same behaviour: whatever
+    # cclib.io.ccread raises internally must come out as a clean TSValueError,
+    # not the original exception type
+    def fake_ccread(source):
+        raise ValueError("some internal cclib parsing failure")
+
+    monkeypatch.setattr(cclib.io, "ccread", fake_ccread)
+    with pytest.raises(TSValueError, match="cclib raised ValueError.*some internal"):
+        read_cclib("whatever.log")

--- a/tests/data/calculator/gaussian/README.md
+++ b/tests/data/calculator/gaussian/README.md
@@ -5,10 +5,14 @@ genuine (non-mocked) Gaussian output.
   job. Parses successfully; used as the real-data success-path test.
 - `mp2_avdz_freq_tight.log` — an MP2/aug-cc-pVDZ frequency job whose "Leave
   Link" timing line (`MaxMem=... cpu: ... elap: ...`) crashes cclib 1.8.1's
-  Gaussian parser with an unhandled `ValueError` (confirmed: still the latest
-  cclib release at the time). Used as the regression test for wrapping any
-  cclib parsing exception into a clean `TSValueError` instead of letting it
-  escape uncontrolled.
+  Gaussian parser (confirmed: still the latest cclib release at the time).
+  Root cause is an unhandled `ValueError` inside cclib's own parser; what
+  actually reaches `read_cclib` depends on the surrounding logging setup (a
+  bare `cclib.io.ccread` call raises that `ValueError` directly, but cclib's
+  own `logger.error()` call right before it can itself raise first under some
+  logging configurations -- either way, `read_cclib` wraps whatever comes out
+  into a clean `TSValueError`). Used as the regression test for that
+  wrapping, so no cclib parsing exception escapes uncontrolled.
 
 Source: [cclib/cclib-data](https://github.com/cclib/cclib-data), the cclib
 project's own public regression-test data, `Gaussian/Gaussian16/`.

--- a/tests/data/calculator/gaussian/README.md
+++ b/tests/data/calculator/gaussian/README.md
@@ -1,0 +1,14 @@
+Real Gaussian 16 log files, used to test `read_cclib`/`cclib_thermo` against
+genuine (non-mocked) Gaussian output.
+
+- `water_neutral_opt_freq.out` — a clean neutral water optimization + frequency
+  job. Parses successfully; used as the real-data success-path test.
+- `mp2_avdz_freq_tight.log` — an MP2/aug-cc-pVDZ frequency job whose "Leave
+  Link" timing line (`MaxMem=... cpu: ... elap: ...`) crashes cclib 1.8.1's
+  Gaussian parser with an unhandled `ValueError` (confirmed: still the latest
+  cclib release at the time). Used as the regression test for wrapping any
+  cclib parsing exception into a clean `TSValueError` instead of letting it
+  escape uncontrolled.
+
+Source: [cclib/cclib-data](https://github.com/cclib/cclib-data), the cclib
+project's own public regression-test data, `Gaussian/Gaussian16/`.

--- a/tests/data/calculator/gaussian/mp2_avdz_freq_tight.log
+++ b/tests/data/calculator/gaussian/mp2_avdz_freq_tight.log
@@ -1,0 +1,2472 @@
+ Entering Gaussian System, Link 0=g16
+ Input=o_proto.gjf
+ Output=o_proto.log
+ Initial command:
+ /ihome/crc/install/gaussian/c01/avx2/tar/g16/l1.exe "/scratch/slurm-11520199/Gau-14592.inp" -scrdir="/scratch/slurm-11520199/"
+ Entering Link 1 = /ihome/crc/install/gaussian/c01/avx2/tar/g16/l1.exe PID=     14593.
+  
+ Copyright (c) 1988-2019, Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 16 program.  It is based on
+ the Gaussian(R) 09 system (copyright 2009, Gaussian, Inc.),
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 16, Revision C.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, 
+ G. A. Petersson, H. Nakatsuji, X. Li, M. Caricato, A. V. Marenich, 
+ J. Bloino, B. G. Janesko, R. Gomperts, B. Mennucci, H. P. Hratchian, 
+ J. V. Ortiz, A. F. Izmaylov, J. L. Sonnenberg, D. Williams-Young, 
+ F. Ding, F. Lipparini, F. Egidi, J. Goings, B. Peng, A. Petrone, 
+ T. Henderson, D. Ranasinghe, V. G. Zakrzewski, J. Gao, N. Rega, 
+ G. Zheng, W. Liang, M. Hada, M. Ehara, K. Toyota, R. Fukuda, 
+ J. Hasegawa, M. Ishida, T. Nakajima, Y. Honda, O. Kitao, H. Nakai, 
+ T. Vreven, K. Throssell, J. A. Montgomery, Jr., J. E. Peralta, 
+ F. Ogliaro, M. J. Bearpark, J. J. Heyd, E. N. Brothers, K. N. Kudin, 
+ V. N. Staroverov, T. A. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. P. Rendell, J. C. Burant, S. S. Iyengar, 
+ J. Tomasi, M. Cossi, J. M. Millam, M. Klene, C. Adamo, R. Cammi, 
+ J. W. Ochterski, R. L. Martin, K. Morokuma, O. Farkas, 
+ J. B. Foresman, and D. J. Fox, Gaussian, Inc., Wallingford CT, 2019.
+ 
+ ******************************************
+ Gaussian 16:  ES64L-G16RevC.01  3-Jul-2019
+                16-Oct-2023 
+ ******************************************
+ %chk=o_proto.chk
+ %nprocshared=32
+ Will use up to   32 processors via shared memory.
+ %mem=1300GB
+ ---------------------------------------
+ #P freq mp2/aug-cc-pvdz Symmetry=Follow
+ ---------------------------------------
+ 1/10=4,30=1,38=1/1,3;
+ 2/12=2,17=6,18=5,40=1/2;
+ 3/5=16,7=10,11=9,25=1,30=1,71=2,140=1/1,2,3;
+ 4//1;
+ 5/5=2,38=5,98=1/2;
+ 8/6=3,8=1,10=1,19=11,30=-1/1;
+ 9/15=3,16=-3/6;
+ 11/6=1,8=1,15=11,17=12,24=-1,27=1,28=-2,29=300,32=6,42=3/1,2,10;
+ 10/6=2,21=1/2;
+ 8/6=4,8=1,10=1,19=11,30=-1/11,4;
+ 10/5=1,20=4/2;
+ 11/12=2,14=11,16=1,17=2,28=-2,42=3,76=2/2,10,12;
+ 6/7=2,8=2,9=2,10=2/1;
+ 7/8=1,10=1,12=2,25=1,44=2/1,2,3,16;
+ 1/10=4,30=1/3;
+ 99//99;
+ Leave Link    1 at Mon Oct 16 00:52:40 2023, MaxMem=174483046400 cpu:               0.5 elap:               0.0
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l101.exe)
+ ---------
+ Oproto sp
+ ---------
+ Symbolic Z-matrix:
+ Charge =  1 Multiplicity = 1
+ C                    -0.00055   0.1331    0.0065 
+ C                    -1.42863   0.24297   0.00761 
+ C                     0.59016  -1.16158   0.01952 
+ C                     0.84038   1.27945  -0.00753 
+ O                    -2.16581  -0.81569   0.04571 
+ O                    -2.09414   1.38924  -0.02387 
+ H                    -3.16311  -0.60053   0.00855 
+ H                    -1.48398   2.14499  -0.0719 
+ C                     1.97081  -1.3024    0.01606 
+ H                    -0.04808  -2.04745   0.03063 
+ C                     2.81803  -0.15533   0.00046 
+ H                     2.41671  -2.30128   0.0249 
+ N                     4.1669   -0.29354  -0.00277 
+ C                     2.22269   1.13989  -0.01046 
+ H                     4.77767   0.51326  -0.01593 
+ H                     4.5993   -1.20862   0.00377 
+ H                     2.8605    2.0282   -0.01999 
+ H                     0.43805   2.29878  -0.01156 
+ O                    -4.69404  -0.40318  -0.14814 
+ H                    -5.27309  -1.17216  -0.24959 
+ H                    -5.18536   0.22406   0.40082 
+ 
+ ITRead=  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+ ITRead=  0
+ MicOpt= -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+ MicOpt= -1
+ NAtoms=     21 NQM=       21 NQMF=       0 NMMI=      0 NMMIF=      0
+                NMic=       0 NMicF=      0.
+                    Isotopes and Nuclear Properties:
+ (Nuclear quadrupole moments (NQMom) in fm**2, nuclear magnetic moments (NMagM)
+  in nuclear magnetons)
+
+  Atom         1           2           3           4           5           6           7           8           9          10
+ IAtWgt=          12          12          12          12          16          16           1           1          12           1
+ AtmWgt=  12.0000000  12.0000000  12.0000000  12.0000000  15.9949146  15.9949146   1.0078250   1.0078250  12.0000000   1.0078250
+ NucSpn=           0           0           0           0           0           0           1           1           0           1
+ AtZEff=  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   2.7928460   2.7928460   0.0000000   2.7928460
+ AtZNuc=   6.0000000   6.0000000   6.0000000   6.0000000   8.0000000   8.0000000   1.0000000   1.0000000   6.0000000   1.0000000
+
+  Atom        11          12          13          14          15          16          17          18          19          20
+ IAtWgt=          12           1          14          12           1           1           1           1          16           1
+ AtmWgt=  12.0000000   1.0078250  14.0030740  12.0000000   1.0078250   1.0078250   1.0078250   1.0078250  15.9949146   1.0078250
+ NucSpn=           0           1           2           0           1           1           1           1           0           1
+ AtZEff=  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000
+ NQMom=    0.0000000   0.0000000   2.0440000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    0.0000000   2.7928460   0.4037610   0.0000000   2.7928460   2.7928460   2.7928460   2.7928460   0.0000000   2.7928460
+ AtZNuc=   6.0000000   1.0000000   7.0000000   6.0000000   1.0000000   1.0000000   1.0000000   1.0000000   8.0000000   1.0000000
+
+  Atom        21
+ IAtWgt=           1
+ AtmWgt=   1.0078250
+ NucSpn=           1
+ AtZEff=  -0.0000000
+ NQMom=    0.0000000
+ NMagM=    2.7928460
+ AtZNuc=   1.0000000
+ Leave Link  101 at Mon Oct 16 00:52:40 2023, MaxMem=174483046400 cpu:               1.7 elap:               0.1
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+ Trust Radius=3.00D-01 FncErr=1.00D-07 GrdErr=1.00D-07 EigMax=2.50D+02 EigMin=1.00D-04
+ Number of steps in this run=      2 maximum allowed number of steps=      2.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Oct 16 00:52:41 2023, MaxMem=174483046400 cpu:               0.7 elap:               0.0
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -0.000547    0.133104    0.006504
+      2          6           0       -1.428627    0.242965    0.007611
+      3          6           0        0.590163   -1.161582    0.019525
+      4          6           0        0.840379    1.279447   -0.007525
+      5          8           0       -2.165809   -0.815686    0.045705
+      6          8           0       -2.094138    1.389241   -0.023875
+      7          1           0       -3.163113   -0.600534    0.008554
+      8          1           0       -1.483982    2.144991   -0.071900
+      9          6           0        1.970812   -1.302401    0.016056
+     10          1           0       -0.048076   -2.047454    0.030630
+     11          6           0        2.818027   -0.155333    0.000461
+     12          1           0        2.416708   -2.301278    0.024903
+     13          7           0        4.166897   -0.293536   -0.002775
+     14          6           0        2.222693    1.139888   -0.010464
+     15          1           0        4.777667    0.513264   -0.015927
+     16          1           0        4.599296   -1.208622    0.003770
+     17          1           0        2.860497    2.028200   -0.019993
+     18          1           0        0.438048    2.298783   -0.011561
+     19          8           0       -4.694036   -0.403178   -0.148141
+     20          1           0       -5.273090   -1.172158   -0.249593
+     21          1           0       -5.185360    0.224060    0.400815
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.432300   0.000000
+     3  C    1.423137   2.459351   0.000000
+     4  C    1.421779   2.494577   2.453969   0.000000
+     5  O    2.364339   1.290593   2.777717   3.664639   0.000000
+     6  O    2.441706   1.325837   3.703249   2.936615   2.207189
+     7  H    3.246544   1.928712   3.794993   4.422955   1.020924
+     8  H    2.500884   1.904492   3.904339   2.481121   3.040449
+     9  C    2.438652   3.734223   1.387816   2.818577   4.165262
+    10  H    2.181209   2.674411   1.091899   3.443702   2.449953
+    11  C    2.833300   4.265298   2.444642   2.443307   5.027597
+    12  H    3.430696   4.610866   2.152952   3.912475   4.817352
+    13  N    4.189236   5.621196   3.680629   3.679677   6.354381
+    14  C    2.440635   3.759912   2.821847   1.389345   4.804829
+    15  H    4.793366   6.212222   4.510161   4.011153   7.069778
+    16  H    4.791533   6.200240   4.009439   4.507779   6.776636
+    17  H    3.431861   4.645903   3.915442   2.154452   5.775445
+    18  H    2.209719   2.776910   3.463846   1.095871   4.059959
+    19  O    4.726558   3.332364   5.340978   5.786255   2.568982
+    20  H    5.437739   4.104707   5.869435   6.591165   3.141571
+    21  H    5.200581   3.777301   5.951643   6.131077   3.213233
+                    6          7          8          9         10
+     6  O    0.000000
+     7  H    2.258975   0.000000
+     8  H    0.972499   3.219295   0.000000
+     9  C    4.875485   5.181685   4.881378   0.000000
+    10  H    4.000027   3.434751   4.432712   2.152029   0.000000
+    11  C    5.149336   5.997691   4.878935   1.426106   3.434469
+    12  H    5.828383   5.833284   5.915579   1.093918   2.477826
+    13  N    6.483267   7.336445   6.154968   2.416807   4.565452
+    14  C    4.324047   5.660065   3.841022   2.455387   3.913724
+    15  H    6.927417   8.018549   6.471006   3.343067   5.463263
+    16  H    7.179952   7.786191   6.946849   2.630185   4.722545
+    17  H    4.995667   6.572286   4.346359   3.447571   5.007327
+    18  H    2.690610   4.623289   1.929117   3.913906   4.373543
+    19  O    3.160329   1.551525   4.099198   6.727240   4.931586
+    20  H    4.088698   2.201226   5.039086   7.249941   5.305227
+    21  H    3.330715   2.218853   4.196860   7.327272   5.629254
+                   11         12         13         14         15
+    11  C    0.000000
+    12  H    2.183285   0.000000
+    13  N    1.355936   2.663636   0.000000
+    14  C    1.425532   3.446813   2.415511   0.000000
+    15  H    2.070623   3.673886   1.011997   2.630700   0.000000
+    16  H    2.069383   2.440908   1.012123   3.341249   1.731212
+    17  H    2.184042   4.352396   2.664102   1.093610   2.443479
+    18  H    3.418645   5.007693   4.541422   2.127909   4.692590
+    19  O    7.517619   7.361753   8.862804   7.088099   9.516854
+    20  H    8.158592   7.777098   9.484000   7.847898  10.193770
+    21  H    8.022370   8.019357   9.375260   7.475770   9.975932
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    3.674371   0.000000
+    18  H    5.442252   2.437529   0.000000
+    19  O    9.329407   7.937191   5.801511   0.000000
+    20  H    9.875703   8.743583   6.687390   0.967949   0.000000
+    21  H    9.896954   8.256380   6.008098   0.967564   1.542775
+                   21
+    21  H    0.000000
+ Stoichiometry    C7H10NO3(1+)
+ Framework group  C1[X(C7H10NO3)]
+ Deg. of freedom    57
+ Full point group                 C1      NOp   1
+ Largest Abelian subgroup         C1      NOp   1
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0        0.004177    0.130116    0.015970
+      2          6           0       -1.424491    0.231383    0.027711
+      3          6           0        0.602695   -1.161041    0.018656
+      4          6           0        0.838112    1.281548    0.001431
+      5          8           0       -2.155041   -0.831849    0.065995
+      6          8           0       -2.097050    1.373773    0.006385
+      7          1           0       -3.153852   -0.622525    0.036930
+      8          1           0       -1.491781    2.133395   -0.042369
+      9          6           0        1.984101   -1.293539    0.004742
+     10          1           0       -0.030142   -2.050777    0.030072
+     11          6           0        2.824310   -0.141338   -0.011404
+     12          1           0        2.436013   -2.289748    0.005685
+     13          7           0        4.173926   -0.271411   -0.024848
+     14          6           0        2.221181    1.150319   -0.011959
+     15          1           0        4.779752    0.539099   -0.038492
+     16          1           0        4.611823   -1.183901   -0.025712
+     17          1           0        2.853579    2.042484   -0.021784
+     18          1           0        0.429676    2.298455    0.005087
+     19          8           0       -4.687003   -0.433641   -0.107980
+     20          1           0       -5.262155   -1.205603   -0.208981
+     21          1           0       -5.178153    0.188041    0.447415
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):           3.4618639           0.4570111           0.4040611
+ Leave Link  202 at Mon Oct 16 00:52:41 2023, MaxMem=174483046400 cpu:               0.3 elap:               0.0
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l301.exe)
+ Standard basis: Aug-CC-pVDZ (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ Ernie:  22 primitive shells out of 345 were deleted.
+ There are   365 symmetry adapted cartesian basis functions of A   symmetry.
+ There are   343 symmetry adapted basis functions of A   symmetry.
+   343 basis functions,   583 primitive gaussians,   365 cartesian basis functions
+    41 alpha electrons       41 beta electrons
+       nuclear repulsion energy       590.0581346706 Hartrees.
+ IExCor=    0 DFT=F Ex=HF Corr=None ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=   21 NActive=   21 NUniq=   21 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Mon Oct 16 00:52:41 2023, MaxMem=174483046400 cpu:               0.9 elap:               0.0
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ One-electron integral symmetry used in STVInt
+ NBasis=   343 RedAO= T EigKep=  1.78D-06  NBF=   343
+ NBsUse=   343 1.00D-06 EigRej= -1.00D+00 NBFU=   343
+ Leave Link  302 at Mon Oct 16 00:52:41 2023, MaxMem=174483046400 cpu:               5.8 elap:               0.2
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Oct 16 00:52:41 2023, MaxMem=174483046400 cpu:               1.0 elap:               0.0
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l401.exe)
+ ExpMin= 2.97D-02 ExpMax= 1.17D+04 ExpMxC= 4.01D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor=  205 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor=  205 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -550.376018409156    
+ JPrj=0 DoOrth=F DoCkMO=F.
+ Leave Link  401 at Mon Oct 16 00:52:42 2023, MaxMem=174483046400 cpu:              12.4 elap:               0.4
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l502.exe)
+ Integral symmetry usage will be decided dynamically.
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ NGot=174483046400 LenX=174482764330 LenY=174482630664
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Fock matrices will be formed incrementally for  20 cycles.
+
+ Cycle   1  Pass 1  IDiag  1:
+ FoFJK:  IHMeth= 1 ICntrl=       0 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf= 950000000 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=         0 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ E= -549.472105334205    
+ DIIS: error= 2.98D-02 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -549.472105334205     IErMin= 1 ErrMin= 2.98D-02
+ ErrMax= 2.98D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.27D-01 BMatP= 5.27D-01
+ IDIUse=3 WtCom= 7.02D-01 WtEn= 2.98D-01
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.329 Goal=   None    Shift=    0.000
+ GapD=    0.329 DampG=1.000 DampE=0.500 DampFc=0.5000 IDamp=-1.
+ Damping current iteration by 5.00D-01
+ RMSDP=6.47D-02 MaxDP=3.74D+00              OVMax= 1.48D-01
+
+ Cycle   2  Pass 1  IDiag  1:
+ RMSU=  1.25D-02    CP:  7.57D-01
+ E= -549.661082079567     Delta-E=       -0.188976745362 Rises=F Damp=T
+ DIIS: error= 1.10D-02 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -549.661082079567     IErMin= 2 ErrMin= 1.10D-02
+ ErrMax= 1.10D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 9.73D-02 BMatP= 5.27D-01
+ IDIUse=3 WtCom= 8.90D-01 WtEn= 1.10D-01
+ Coeff-Com: -0.534D+00 0.153D+01
+ Coeff-En:   0.000D+00 0.100D+01
+ Coeff:     -0.475D+00 0.148D+01
+ Gap=     0.380 Goal=   None    Shift=    0.000
+ RMSDP=3.22D-02 MaxDP=1.98D+00 DE=-1.89D-01 OVMax= 6.81D-02
+
+ Cycle   3  Pass 1  IDiag  1:
+ RMSU=  3.23D-03    CP:  5.10D-01  1.82D+00
+ E= -549.832688883068     Delta-E=       -0.171606803501 Rises=F Damp=F
+ DIIS: error= 1.99D-03 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -549.832688883068     IErMin= 3 ErrMin= 1.99D-03
+ ErrMax= 1.99D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.33D-03 BMatP= 9.73D-02
+ IDIUse=3 WtCom= 9.80D-01 WtEn= 1.99D-02
+ Coeff-Com: -0.153D+00 0.260D+00 0.893D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.150D+00 0.255D+00 0.895D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.74D-03 MaxDP=1.31D-01 DE=-1.72D-01 OVMax= 2.08D-02
+
+ Cycle   4  Pass 1  IDiag  1:
+ RMSU=  1.00D-03    CP:  4.99D-01  1.86D+00  1.02D+00
+ E= -549.836860515560     Delta-E=       -0.004171632492 Rises=F Damp=F
+ DIIS: error= 9.56D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -549.836860515560     IErMin= 4 ErrMin= 9.56D-04
+ ErrMax= 9.56D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.12D-04 BMatP= 4.33D-03
+ IDIUse=3 WtCom= 9.90D-01 WtEn= 9.56D-03
+ Coeff-Com: -0.223D-01 0.197D-01 0.203D+00 0.800D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.221D-01 0.195D-01 0.201D+00 0.802D+00
+ Gap=     0.360 Goal=   None    Shift=    0.000
+ RMSDP=4.54D-04 MaxDP=2.84D-02 DE=-4.17D-03 OVMax= 7.76D-03
+
+ Cycle   5  Pass 1  IDiag  1:
+ RMSU=  2.65D-04    CP:  4.96D-01  1.87D+00  1.04D+00  1.01D+00
+ E= -549.837315785559     Delta-E=       -0.000455269999 Rises=F Damp=F
+ DIIS: error= 4.60D-04 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -549.837315785559     IErMin= 5 ErrMin= 4.60D-04
+ ErrMax= 4.60D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.89D-05 BMatP= 3.12D-04
+ IDIUse=3 WtCom= 9.95D-01 WtEn= 4.60D-03
+ Coeff-Com:  0.137D-01-0.245D-01-0.927D-01 0.468D-01 0.106D+01
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.100D+01
+ Coeff:      0.137D-01-0.244D-01-0.923D-01 0.466D-01 0.106D+01
+ Gap=     0.361 Goal=   None    Shift=    0.000
+ RMSDP=2.87D-04 MaxDP=1.31D-02 DE=-4.55D-04 OVMax= 5.62D-03
+
+ Cycle   6  Pass 1  IDiag  1:
+ RMSU=  1.70D-04    CP:  4.96D-01  1.87D+00  1.08D+00  1.18D+00  1.25D+00
+ E= -549.837453123045     Delta-E=       -0.000137337486 Rises=F Damp=F
+ DIIS: error= 2.69D-04 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -549.837453123045     IErMin= 6 ErrMin= 2.69D-04
+ ErrMax= 2.69D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.06D-05 BMatP= 4.89D-05
+ IDIUse=3 WtCom= 9.97D-01 WtEn= 2.69D-03
+ Coeff-Com:  0.598D-02-0.762D-02-0.481D-01-0.133D+00 0.205D+00 0.978D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.100D+01
+ Coeff:      0.596D-02-0.760D-02-0.479D-01-0.133D+00 0.204D+00 0.978D+00
+ Gap=     0.362 Goal=   None    Shift=    0.000
+ RMSDP=1.20D-04 MaxDP=4.45D-03 DE=-1.37D-04 OVMax= 3.24D-03
+
+ Cycle   7  Pass 1  IDiag  1:
+ RMSU=  4.91D-05    CP:  4.95D-01  1.87D+00  1.10D+00  1.23D+00  1.46D+00
+                    CP:  1.35D+00
+ E= -549.837488464848     Delta-E=       -0.000035341804 Rises=F Damp=F
+ DIIS: error= 8.27D-05 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -549.837488464848     IErMin= 7 ErrMin= 8.27D-05
+ ErrMax= 8.27D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.92D-06 BMatP= 1.06D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.300D-02 0.513D-02 0.236D-01-0.124D-01-0.215D+00-0.955D-02
+ Coeff-Com:  0.121D+01
+ Coeff:     -0.300D-02 0.513D-02 0.236D-01-0.124D-01-0.215D+00-0.955D-02
+ Coeff:      0.121D+01
+ Gap=     0.363 Goal=   None    Shift=    0.000
+ RMSDP=7.21D-05 MaxDP=2.69D-03 DE=-3.53D-05 OVMax= 2.04D-03
+
+ Cycle   8  Pass 1  IDiag  1:
+ RMSU=  2.55D-05    CP:  4.95D-01  1.87D+00  1.11D+00  1.24D+00  1.57D+00
+                    CP:  1.64D+00  1.27D+00
+ E= -549.837497435698     Delta-E=       -0.000008970849 Rises=F Damp=F
+ DIIS: error= 4.59D-05 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -549.837497435698     IErMin= 8 ErrMin= 4.59D-05
+ ErrMax= 4.59D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.84D-07 BMatP= 1.92D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.112D-02 0.149D-02 0.985D-02 0.190D-01-0.340D-01-0.142D+00
+ Coeff-Com: -0.446D-01 0.119D+01
+ Coeff:     -0.112D-02 0.149D-02 0.985D-02 0.190D-01-0.340D-01-0.142D+00
+ Coeff:     -0.446D-01 0.119D+01
+ Gap=     0.363 Goal=   None    Shift=    0.000
+ RMSDP=3.02D-05 MaxDP=9.92D-04 DE=-8.97D-06 OVMax= 9.18D-04
+
+ Cycle   9  Pass 1  IDiag  1:
+ RMSU=  8.33D-06    CP:  4.95D-01  1.87D+00  1.11D+00  1.25D+00  1.62D+00
+                    CP:  1.76D+00  1.34D+00  1.51D+00
+ E= -549.837498989280     Delta-E=       -0.000001553583 Rises=F Damp=F
+ DIIS: error= 1.64D-05 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -549.837498989280     IErMin= 9 ErrMin= 1.64D-05
+ ErrMax= 1.64D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.37D-08 BMatP= 2.84D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.292D-03-0.544D-03-0.208D-02-0.607D-03 0.223D-01 0.553D-02
+ Coeff-Com: -0.157D+00 0.627D-02 0.113D+01
+ Coeff:      0.292D-03-0.544D-03-0.208D-02-0.607D-03 0.223D-01 0.553D-02
+ Coeff:     -0.157D+00 0.627D-02 0.113D+01
+ Gap=     0.363 Goal=   None    Shift=    0.000
+ RMSDP=1.00D-05 MaxDP=3.33D-04 DE=-1.55D-06 OVMax= 4.38D-04
+
+ Cycle  10  Pass 1  IDiag  1:
+ RMSU=  2.91D-06    CP:  4.95D-01  1.87D+00  1.11D+00  1.25D+00  1.64D+00
+                    CP:  1.79D+00  1.36D+00  1.69D+00  1.36D+00
+ E= -549.837499237204     Delta-E=       -0.000000247923 Rises=F Damp=F
+ DIIS: error= 5.37D-06 at cycle  10 NSaved=  10.
+ NSaved=10 IEnMin=10 EnMin= -549.837499237204     IErMin=10 ErrMin= 5.37D-06
+ ErrMax= 5.37D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.13D-08 BMatP= 4.37D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.306D-03-0.431D-03-0.228D-02-0.530D-02 0.924D-02 0.376D-01
+ Coeff-Com:  0.575D-02-0.330D+00 0.130D+00 0.115D+01
+ Coeff:      0.306D-03-0.431D-03-0.228D-02-0.530D-02 0.924D-02 0.376D-01
+ Coeff:      0.575D-02-0.330D+00 0.130D+00 0.115D+01
+ Gap=     0.363 Goal=   None    Shift=    0.000
+ RMSDP=5.15D-06 MaxDP=2.54D-04 DE=-2.48D-07 OVMax= 2.15D-04
+
+ Cycle  11  Pass 1  IDiag  1:
+ RMSU=  1.16D-06    CP:  4.95D-01  1.87D+00  1.11D+00  1.25D+00  1.65D+00
+                    CP:  1.81D+00  1.36D+00  1.78D+00  1.58D+00  1.31D+00
+ E= -549.837499281665     Delta-E=       -0.000000044461 Rises=F Damp=F
+ DIIS: error= 1.20D-06 at cycle  11 NSaved=  11.
+ NSaved=11 IEnMin=11 EnMin= -549.837499281665     IErMin=11 ErrMin= 1.20D-06
+ ErrMax= 1.20D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.96D-10 BMatP= 1.13D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.208D-04 0.352D-04 0.286D-03-0.692D-04-0.198D-02-0.157D-02
+ Coeff-Com:  0.176D-01-0.137D-02-0.727D-01-0.713D-01 0.113D+01
+ Coeff:     -0.208D-04 0.352D-04 0.286D-03-0.692D-04-0.198D-02-0.157D-02
+ Coeff:      0.176D-01-0.137D-02-0.727D-01-0.713D-01 0.113D+01
+ Gap=     0.363 Goal=   None    Shift=    0.000
+ RMSDP=9.30D-07 MaxDP=3.32D-05 DE=-4.45D-08 OVMax= 3.52D-05
+
+ Cycle  12  Pass 1  IDiag  1:
+ RMSU=  3.89D-07    CP:  4.95D-01  1.87D+00  1.11D+00  1.25D+00  1.65D+00
+                    CP:  1.81D+00  1.36D+00  1.78D+00  1.57D+00  1.39D+00
+                    CP:  1.30D+00
+ E= -549.837499283336     Delta-E=       -0.000000001671 Rises=F Damp=F
+ DIIS: error= 3.21D-07 at cycle  12 NSaved=  12.
+ NSaved=12 IEnMin=12 EnMin= -549.837499283336     IErMin=12 ErrMin= 3.21D-07
+ ErrMax= 3.21D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.05D-11 BMatP= 4.96D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.279D-04 0.391D-04 0.257D-03 0.399D-03-0.105D-02-0.415D-02
+ Coeff-Com:  0.300D-02 0.272D-01-0.169D-01-0.119D+00 0.171D+00 0.939D+00
+ Coeff:     -0.279D-04 0.391D-04 0.257D-03 0.399D-03-0.105D-02-0.415D-02
+ Coeff:      0.300D-02 0.272D-01-0.169D-01-0.119D+00 0.171D+00 0.939D+00
+ Gap=     0.363 Goal=   None    Shift=    0.000
+ RMSDP=2.55D-07 MaxDP=1.04D-05 DE=-1.67D-09 OVMax= 9.58D-06
+
+ Cycle  13  Pass 1  IDiag  1:
+ RMSU=  1.10D-07    CP:  4.95D-01  1.87D+00  1.11D+00  1.25D+00  1.65D+00
+                    CP:  1.81D+00  1.37D+00  1.78D+00  1.56D+00  1.39D+00
+                    CP:  1.38D+00  1.22D+00
+ E= -549.837499283483     Delta-E=       -0.000000000147 Rises=F Damp=F
+ DIIS: error= 1.43D-07 at cycle  13 NSaved=  13.
+ NSaved=13 IEnMin=13 EnMin= -549.837499283483     IErMin=13 ErrMin= 1.43D-07
+ ErrMax= 1.43D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.08D-11 BMatP= 7.05D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.105D-05-0.206D-05-0.247D-04-0.121D-04 0.303D-03-0.145D-03
+ Coeff-Com: -0.171D-02-0.253D-03 0.103D-01 0.539D-02-0.166D+00 0.717D-01
+ Coeff-Com:  0.108D+01
+ Coeff:      0.105D-05-0.206D-05-0.247D-04-0.121D-04 0.303D-03-0.145D-03
+ Coeff:     -0.171D-02-0.253D-03 0.103D-01 0.539D-02-0.166D+00 0.717D-01
+ Coeff:      0.108D+01
+ Gap=     0.363 Goal=   None    Shift=    0.000
+ RMSDP=1.00D-07 MaxDP=3.72D-06 DE=-1.47D-10 OVMax= 4.03D-06
+
+ Cycle  14  Pass 1  IDiag  1:
+ RMSU=  4.15D-08    CP:  4.95D-01  1.87D+00  1.11D+00  1.25D+00  1.65D+00
+                    CP:  1.81D+00  1.37D+00  1.78D+00  1.56D+00  1.39D+00
+                    CP:  1.40D+00  1.33D+00  1.41D+00
+ E= -549.837499283524     Delta-E=       -0.000000000041 Rises=F Damp=F
+ DIIS: error= 3.30D-08 at cycle  14 NSaved=  14.
+ NSaved=14 IEnMin=14 EnMin= -549.837499283524     IErMin=14 ErrMin= 3.30D-08
+ ErrMax= 3.30D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.09D-12 BMatP= 1.08D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.325D-05-0.458D-05-0.312D-04-0.595D-04 0.171D-03 0.442D-03
+ Coeff-Com: -0.188D-03-0.362D-02 0.281D-02 0.159D-01-0.299D-01-0.973D-01
+ Coeff-Com:  0.271D-01 0.108D+01
+ Coeff:      0.325D-05-0.458D-05-0.312D-04-0.595D-04 0.171D-03 0.442D-03
+ Coeff:     -0.188D-03-0.362D-02 0.281D-02 0.159D-01-0.299D-01-0.973D-01
+ Coeff:      0.271D-01 0.108D+01
+ Gap=     0.363 Goal=   None    Shift=    0.000
+ RMSDP=3.88D-08 MaxDP=1.60D-06 DE=-4.12D-11 OVMax= 8.61D-07
+
+ Cycle  15  Pass 1  IDiag  1:
+ RMSU=  1.44D-08    CP:  4.95D-01  1.87D+00  1.11D+00  1.25D+00  1.65D+00
+                    CP:  1.81D+00  1.37D+00  1.78D+00  1.56D+00  1.39D+00
+                    CP:  1.40D+00  1.34D+00  1.57D+00  1.35D+00
+ E= -549.837499283524     Delta-E=        0.000000000000 Rises=F Damp=F
+ DIIS: error= 1.48D-08 at cycle  15 NSaved=  15.
+ NSaved=15 IEnMin=14 EnMin= -549.837499283524     IErMin=15 ErrMin= 1.48D-08
+ ErrMax= 1.48D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.17D-13 BMatP= 1.09D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.501D-06-0.676D-06-0.274D-05-0.103D-04 0.113D-05 0.699D-04
+ Coeff-Com:  0.173D-03-0.710D-03-0.721D-03 0.240D-02 0.122D-01-0.218D-01
+ Coeff-Com: -0.121D+00 0.169D+00 0.960D+00
+ Coeff:      0.501D-06-0.676D-06-0.274D-05-0.103D-04 0.113D-05 0.699D-04
+ Coeff:      0.173D-03-0.710D-03-0.721D-03 0.240D-02 0.122D-01-0.218D-01
+ Coeff:     -0.121D+00 0.169D+00 0.960D+00
+ Gap=     0.363 Goal=   None    Shift=    0.000
+ RMSDP=1.12D-08 MaxDP=4.49D-07 DE= 4.55D-13 OVMax= 4.19D-07
+
+ Cycle  16  Pass 1  IDiag  1:
+ RMSU=  4.39D-09    CP:  4.95D-01  1.87D+00  1.11D+00  1.25D+00  1.65D+00
+                    CP:  1.81D+00  1.37D+00  1.78D+00  1.56D+00  1.39D+00
+                    CP:  1.40D+00  1.34D+00  1.62D+00  1.42D+00  1.18D+00
+ E= -549.837499283531     Delta-E=       -0.000000000007 Rises=F Damp=F
+ DIIS: error= 4.52D-09 at cycle  16 NSaved=  16.
+ NSaved=16 IEnMin=16 EnMin= -549.837499283531     IErMin=16 ErrMin= 4.52D-09
+ ErrMax= 4.52D-09  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.28D-14 BMatP= 1.17D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.295D-06 0.413D-06 0.323D-05 0.513D-05-0.174D-04-0.471D-04
+ Coeff-Com:  0.334D-04 0.331D-03-0.355D-03-0.151D-02 0.331D-02 0.111D-01
+ Coeff-Com: -0.765D-02-0.117D+00 0.692D-01 0.104D+01
+ Coeff:     -0.295D-06 0.413D-06 0.323D-05 0.513D-05-0.174D-04-0.471D-04
+ Coeff:      0.334D-04 0.331D-03-0.355D-03-0.151D-02 0.331D-02 0.111D-01
+ Coeff:     -0.765D-02-0.117D+00 0.692D-01 0.104D+01
+ Gap=     0.363 Goal=   None    Shift=    0.000
+ RMSDP=3.50D-09 MaxDP=1.05D-07 DE=-7.05D-12 OVMax= 1.03D-07
+
+ SCF Done:  E(RHF) =  -549.837499284     A.U. after   16 cycles
+            NFock= 16  Conv=0.35D-08     -V/T= 2.0018
+ KE= 5.488367318002D+02 PE=-2.457137179811D+03 EE= 7.684048140563D+02
+ Leave Link  502 at Mon Oct 16 00:53:02 2023, MaxMem=174483046400 cpu:             649.8 elap:              20.4
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l801.exe)
+ ExpMin= 2.97D-02 ExpMax= 1.17D+04 ExpMxC= 4.01D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ HarFok:  IExCor=  205 AccDes= 0.00D+00 IRadAn=         5 IDoV=-2 UseB2=F ITyADJ=14
+ ICtDFT= 12500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ Largest valence mixing into a core orbital is  1.14D-04
+ Largest core mixing into a valence orbital is  4.50D-05
+ Range of M.O.s used for correlation:    12   343
+ NBasis=   343 NAE=    41 NBE=    41 NFC=    11 NFV=     0
+ NROrb=    332 NOA=    30 NOB=    30 NVA=   302 NVB=   302
+
+ **** Warning!!: The largest alpha MO coefficient is  0.13412149D+03
+
+ Leave Link  801 at Mon Oct 16 00:53:02 2023, MaxMem=174483046400 cpu:               1.9 elap:               0.1
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l906.exe)
+ Frozen-core derivative calculation, NFC=  11 NFV=   0.
+ FulOut=F Deriv=T AODrv=T NAtomX=    21
+   MMem=           0  MDisk=          30 MDiskD=          30
+  W3Min=     5132995 MinDsk=    15052960 NBas6D=         365
+ NBas2D=       67284    NTT=       66795    LW2=     3300000
+    MDV=174481441129 MDiskM=     6639248 NBas2p=       64394
+ Disk-based method using ON**2 memory for 30 occupieds at a time.
+ Permanent disk used for amplitudes=   190583744 words.
+ Estimated scratch disk usage=  2691982738 words.
+ IMap=   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20
+ IMap=  21  22  23  24  25  26  27  28  29  30  31  32  33  34  35  36  37  38  39  40
+ IMap=  41
+ Actual    scratch disk usage=  2449960850 words.
+ JobTyp=1 Pass  1:  I=  12 to  41 NPSUse= 32 ParTrn=T ParDer=T DoDerP=T.
+ (rs|ai) integrals will be sorted in core.
+ Spin components of T(2) and E(2):
+     alpha-alpha T2 =       0.7930576014D-01 E2=     -0.2309384718D+00
+     alpha-beta  T2 =       0.4086856906D+00 E2=     -0.1258639494D+01
+     beta-beta   T2 =       0.7930576014D-01 E2=     -0.2309384718D+00
+ The integrals were generated   1 times.
+ ANorm=    0.1251917414D+01
+ E2 =    -0.1720516438D+01 EUMP2 =    -0.55155801572117D+03
+ Leave Link  906 at Mon Oct 16 01:00:45 2023, MaxMem=174483046400 cpu:           14727.6 elap:             461.4
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l1101.exe)
+ Using compressed Sx but separate Hx and Fx, NAtomX=    21.
+ Will process     22 centers per pass.
+ Leave Link 1101 at Mon Oct 16 01:00:46 2023, MaxMem=174483046400 cpu:               9.3 elap:               0.3
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l1102.exe)
+ Leave Link 1102 at Mon Oct 16 01:00:47 2023, MaxMem=174483046400 cpu:               0.8 elap:               0.0
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l1110.exe)
+ Forming Gx(P) for the SCF density, NAtomX=    21.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Do as many integral derivatives as possible in FoFJK.
+ G2DrvN: MDV=  174483044143.
+ G2DrvN: will do    22 centers at a time, making    1 passes.
+ Calling FoFCou, ICntrl=  3107 FMM=F I1Cent=   0 AccDes= 0.00D+00.
+ FoFJK:  IHMeth= 1 ICntrl=    3107 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         0 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=      3107 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ End of G2Drv F.D. properties file   721 does not exist.
+ End of G2Drv F.D. properties file   722 does not exist.
+ End of G2Drv F.D. properties file   788 does not exist.
+ Leave Link 1110 at Mon Oct 16 01:00:56 2023, MaxMem=174483046400 cpu:             266.7 elap:               8.4
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l1002.exe)
+ Minotr:  Closed shell wavefunction.
+          IDoAtm=111111111111111111111
+          Frozen-core window.
+          Direct CPHF calculation.
+          Differentiating once with respect to electric field.
+                with respect to dipole field.
+          Differentiating once with respect to nuclear coordinates.
+          Requested convergence is 1.0D-08 RMS, and 1.0D-07 maximum.
+          Secondary convergence is 1.0D-12 RMS, and 1.0D-12 maximum.
+          NewPWx=T KeepS1=T KeepF1=T KeepIn=T MapXYZ=F SortEE=F KeepMc=T.
+ Keep R1 ints in memory in canonical form, NReq=1764812661.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=       600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  58996 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Two-electron integral symmetry not used.
+          MDV=  174483046400 using IRadAn=       1.
+          Solving linear equations simultaneously, MaxMat=       0.
+          There are    66 degrees of freedom in the 1st order CPHF.  IDoFFX=6 NUNeed=    66.
+     63 vectors produced by pass  0 Test12= 1.88D-14 1.52D-09 XBig12= 6.55D+01 6.28D+00.
+ AX will form    63 AO Fock derivatives at one time.
+     63 vectors produced by pass  1 Test12= 1.88D-14 1.52D-09 XBig12= 5.47D+00 6.05D-01.
+     63 vectors produced by pass  2 Test12= 1.88D-14 1.52D-09 XBig12= 1.96D-01 4.88D-02.
+     63 vectors produced by pass  3 Test12= 1.88D-14 1.52D-09 XBig12= 2.89D-03 5.33D-03.
+     63 vectors produced by pass  4 Test12= 1.88D-14 1.52D-09 XBig12= 2.97D-05 4.99D-04.
+     63 vectors produced by pass  5 Test12= 1.88D-14 1.52D-09 XBig12= 2.31D-07 4.66D-05.
+     63 vectors produced by pass  6 Test12= 1.88D-14 1.52D-09 XBig12= 1.49D-09 4.21D-06.
+     38 vectors produced by pass  7 Test12= 1.88D-14 1.52D-09 XBig12= 1.00D-11 2.26D-07.
+      3 vectors produced by pass  8 Test12= 1.88D-14 1.52D-09 XBig12= 5.90D-14 2.47D-08.
+      1 vectors produced by pass  9 Test12= 1.88D-14 1.52D-09 XBig12= 1.73D-16 1.66D-09.
+ InvSVY:  IOpt=1 It=  1 EMax= 3.55D-15
+ Solved reduced A of dimension   483 with    66 vectors.
+ FullF1:  Do perturbations      1 to      66.
+ Saving first derivative matrices.
+ End of Minotr F.D. properties file   721 does not exist.
+ End of Minotr F.D. properties file   722 does not exist.
+ End of Minotr F.D. properties file   788 does not exist.
+ Leave Link 1002 at Mon Oct 16 01:01:15 2023, MaxMem=174483046400 cpu:             536.0 elap:              18.8
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l811.exe)
+ MDV=174483046400.
+ Form MO integral derivatives with frozen-active canonical formalism.
+ MOERI=1 MOERIx=1 NAtoms=    21 NAtomX=    21.
+ Discarding MO integrals.
+ MO basis two electron integral derivatives will not be stored on disk.
+ IAlg= 3 DoFC=T DoPWx=T Debug=F.
+ Frozen-core window:  NFC=  11 NFV=   0.
+ Reordered first order wavefunction length =    306627848
+ In DefCFB: NBatch=  1 ICI= 41 ICA=302 LFMax=151
+            Large arrays: LIAPS=  6200657960 LIARS=   790900250 words.
+ In StABat: MaxSiz= 25 MinSiz= 18 NAtomB= 16
+ DoIAMN: NPSUse= 32.
+ Leave Link  811 at Mon Oct 16 01:18:26 2023, MaxMem=174483046400 cpu:           32856.9 elap:            1030.0
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l804.exe)
+ Frozen-core window:  NFC=  11 NFV=   0.
+ Closed-shell transformation, MDV=174483046400 ITran=4 ISComp=1.
+ Semi-Direct transformation.
+ ModeAB=           4 MOrb=            41 LenV=  174479942435
+ LASXX=    763847876 LTotXX=   763847876 LenRXX=  1534471002
+ LTotAB=   770623126 MaxLAS=   877545263 LenRXY=           0
+ NonZer=  2298318878 LenScr=  3460998144 LnRSAI=   877545263
+ LnScr1=  1321480192 LExtra=           0 Total=   7194494601
+ MaxDsk=          -1 SrtSym=           T ITran=            4
+ DoSDTr:  NPSUse= 32
+ JobTyp=0 Pass  1:  I=   1 to  41.
+ (rs|ai) integrals will be sorted in core.
+ Complete sort for first half transformation.
+ First half transformation complete.
+ Begin second half transformation for I=  10.
+ Begin second half transformation for I=  20.
+ Begin second half transformation for I=  30.
+ Begin second half transformation for I=  40.
+ Complete sort for second half transformation.
+ Second half transformation complete.
+ SymMOI:  orbitals are not symmetric.
+ Spin components of T(2) and E(2):
+     alpha-alpha T2 =       0.7930576014D-01 E2=     -0.2309384718D+00
+     alpha-beta  T2 =       0.4086856906D+00 E2=     -0.1258639494D+01
+     beta-beta   T2 =       0.7930576014D-01 E2=     -0.2309384718D+00
+ ANorm=    0.1770478585D+01
+ E2 =    -0.1720516438D+01 EUMP2 =    -0.55155801572117D+03
+ Leave Link  804 at Mon Oct 16 01:19:54 2023, MaxMem=174483046400 cpu:            2784.9 elap:              87.3
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l1002.exe)
+ Minotr:  Closed shell wavefunction.
+          Computing MP2/KS-MP2 derivatives.
+          Using Z-Vector for PSCF gradient.
+          Skipping F1 and S1 gradient terms here.
+          IDoAtm=111111111111111111111
+          Frozen-core window.
+          Using MO integrals in the linear equations.
+          Forming densities via direct SCF.
+          Differentiating once with respect to electric field.
+                with respect to dipole field.
+          Differentiating once with respect to nuclear coordinates.
+          Requested convergence is 1.0D-10 RMS, and 1.0D-09 maximum.
+          NewPWx=F KeepS1=T KeepF1=T KeepIn=T MapXYZ=F SortEE=F KeepMc=T.
+          MDV=  174483046400 using IRadAn=       5.
+          Solving linear equations separately, MaxMat=       0.
+          There are     1 degrees of freedom in the 1st order CPHF.  IDoFFX=0 NUNeed=     1.
+ FoFJK:  IHMeth= 1 ICntrl=       0 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         0 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=         0 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ LinEq1:  Iter=  0 NonCon=     1 RMS=3.44D-03 Max=1.41D-01 NDo=     1
+ LinEq1:  Iter=  1 NonCon=     1 RMS=9.06D-04 Max=2.31D-02 NDo=     1
+ LinEq1:  Iter=  2 NonCon=     1 RMS=4.26D-04 Max=2.10D-02 NDo=     1
+ LinEq1:  Iter=  3 NonCon=     1 RMS=1.44D-04 Max=8.59D-03 NDo=     1
+ LinEq1:  Iter=  4 NonCon=     1 RMS=6.47D-05 Max=3.11D-03 NDo=     1
+ LinEq1:  Iter=  5 NonCon=     1 RMS=2.53D-05 Max=1.53D-03 NDo=     1
+ LinEq1:  Iter=  6 NonCon=     1 RMS=8.42D-06 Max=1.23D-04 NDo=     1
+ LinEq1:  Iter=  7 NonCon=     1 RMS=2.33D-06 Max=7.02D-05 NDo=     1
+ LinEq1:  Iter=  8 NonCon=     1 RMS=7.08D-07 Max=1.46D-05 NDo=     1
+ LinEq1:  Iter=  9 NonCon=     1 RMS=2.77D-07 Max=6.27D-06 NDo=     1
+ LinEq1:  Iter= 10 NonCon=     1 RMS=7.68D-08 Max=1.39D-06 NDo=     1
+ LinEq1:  Iter= 11 NonCon=     1 RMS=2.44D-08 Max=5.37D-07 NDo=     1
+ LinEq1:  Iter= 12 NonCon=     1 RMS=8.21D-09 Max=1.90D-07 NDo=     1
+ LinEq1:  Iter= 13 NonCon=     1 RMS=2.82D-09 Max=8.68D-08 NDo=     1
+ LinEq1:  Iter= 14 NonCon=     1 RMS=1.03D-09 Max=3.15D-08 NDo=     1
+ LinEq1:  Iter= 15 NonCon=     1 RMS=3.26D-10 Max=1.35D-08 NDo=     1
+ LinEq1:  Iter= 16 NonCon=     1 RMS=1.17D-10 Max=4.67D-09 NDo=     1
+ LinEq1:  Iter= 17 NonCon=     0 RMS=4.31D-11 Max=9.80D-10 NDo=     1
+ Linear equations converged to 1.000D-10 1.000D-09 after    17 iterations.
+ End of Minotr F.D. properties file   721 does not exist.
+ End of Minotr F.D. properties file   722 does not exist.
+ End of Minotr F.D. properties file   788 does not exist.
+ Leave Link 1002 at Mon Oct 16 01:20:10 2023, MaxMem=174483046400 cpu:             502.8 elap:              16.0
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l1102.exe)
+ Use density number 2.
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+ Leave Link 1102 at Mon Oct 16 01:20:10 2023, MaxMem=174483046400 cpu:               1.0 elap:               0.0
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l1110.exe)
+ Forming Gx(P) for generalized density number  2 NAtomX=    21.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Do as many integral derivatives as possible in FoFJK.
+ G2DrvN: MDV=  174483044143.
+ G2DrvN: will do    22 centers at a time, making    1 passes.
+ Calling FoFCou, ICntrl=  3107 FMM=F I1Cent=   0 AccDes= 0.00D+00.
+ FoFJK:  IHMeth= 1 ICntrl=    3107 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         0 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=      3107 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ End of G2Drv F.D. properties file   721 does not exist.
+ End of G2Drv F.D. properties file   722 does not exist.
+ End of G2Drv F.D. properties file   788 does not exist.
+ Leave Link 1110 at Mon Oct 16 01:20:18 2023, MaxMem=174483046400 cpu:             263.5 elap:               8.3
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l1112.exe)
+ MP22nd: MDV=  174483046400
+ This link is doing NAtomX=    21 total of    66 degrees of freedom.
+ Using ON3 I/O method in MakUI.
+ Frozen-core window:  NFC=  11 NFV=   0.
+ Using Ix for Sx.
+ Use MO integrals over full window.
+ Using OV2 memory method for fx*t*t/D, MaxI=    41 DoOO2=F NP=  32.
+ R2 and R3 integrals will be kept in memory, NReq=  4486152585.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=       600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ DD1Dir will call FoFMem   1 times, MxPair=      1722
+ NAB=   861 NAA=     0 NBB=     0.
+ Symmetry is being used.
+ FoFJK:  IHMeth= 1 ICntrl=       0 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         0 NMat=      66 IRICut=     165 DoRegI=T DoRafI=T ISym2E= 2 IDoP0=3 IntGTp=3.
+ Discarding MO integrals.
+ Leave Link 1112 at Mon Oct 16 01:26:35 2023, MaxMem=174483046400 cpu:           11970.9 elap:             375.6
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l601.exe)
+ Copying SCF densities to generalized density rwf, IOpCl= 0 IROHF=0.
+
+ **********************************************************************
+
+            Population analysis using the SCF Density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A)
+ The electronic state is 1-A.
+ Alpha  occ. eigenvalues --  -20.80684 -20.77683 -20.74264 -15.73121 -11.59523
+ Alpha  occ. eigenvalues --  -11.46637 -11.42649 -11.41500 -11.39996 -11.38614
+ Alpha  occ. eigenvalues --  -11.38104  -1.66463  -1.56980  -1.52104  -1.38811
+ Alpha  occ. eigenvalues --   -1.29696  -1.18180  -1.17425  -1.06818  -1.00111
+ Alpha  occ. eigenvalues --   -0.99500  -0.95438  -0.89548  -0.88094  -0.86245
+ Alpha  occ. eigenvalues --   -0.84811  -0.82164  -0.80126  -0.78189  -0.75993
+ Alpha  occ. eigenvalues --   -0.74850  -0.73956  -0.72254  -0.69712  -0.69222
+ Alpha  occ. eigenvalues --   -0.68396  -0.67416  -0.64485  -0.60285  -0.49604
+ Alpha  occ. eigenvalues --   -0.44889
+ Alpha virt. eigenvalues --   -0.08592  -0.07221  -0.05920  -0.05437  -0.04339
+ Alpha virt. eigenvalues --   -0.03720  -0.02979  -0.02541  -0.02151  -0.01535
+ Alpha virt. eigenvalues --   -0.00848   0.00413   0.00621   0.01722   0.01996
+ Alpha virt. eigenvalues --    0.02862   0.03116   0.03232   0.04109   0.04795
+ Alpha virt. eigenvalues --    0.05336   0.05860   0.05915   0.06237   0.06617
+ Alpha virt. eigenvalues --    0.06905   0.07855   0.08489   0.08820   0.09264
+ Alpha virt. eigenvalues --    0.09530   0.10302   0.10429   0.10775   0.11238
+ Alpha virt. eigenvalues --    0.12551   0.13212   0.13753   0.14048   0.14644
+ Alpha virt. eigenvalues --    0.15035   0.15461   0.16460   0.16817   0.17810
+ Alpha virt. eigenvalues --    0.18050   0.18568   0.19037   0.20241   0.20463
+ Alpha virt. eigenvalues --    0.21034   0.21349   0.21787   0.22136   0.22282
+ Alpha virt. eigenvalues --    0.23237   0.23821   0.24350   0.25322   0.26473
+ Alpha virt. eigenvalues --    0.27049   0.27076   0.27521   0.28432   0.29290
+ Alpha virt. eigenvalues --    0.29698   0.30328   0.30696   0.30865   0.31463
+ Alpha virt. eigenvalues --    0.32238   0.32533   0.33271   0.33922   0.34941
+ Alpha virt. eigenvalues --    0.35753   0.37276   0.37494   0.38831   0.39401
+ Alpha virt. eigenvalues --    0.39499   0.39984   0.41630   0.42745   0.43085
+ Alpha virt. eigenvalues --    0.43729   0.44461   0.45225   0.45818   0.46870
+ Alpha virt. eigenvalues --    0.47273   0.47879   0.48299   0.48526   0.50997
+ Alpha virt. eigenvalues --    0.52264   0.52822   0.53294   0.53894   0.54444
+ Alpha virt. eigenvalues --    0.54521   0.55101   0.55277   0.55862   0.56533
+ Alpha virt. eigenvalues --    0.56765   0.57707   0.57925   0.58597   0.58831
+ Alpha virt. eigenvalues --    0.59946   0.60918   0.61504   0.61771   0.62608
+ Alpha virt. eigenvalues --    0.62810   0.64960   0.65963   0.66087   0.67488
+ Alpha virt. eigenvalues --    0.69199   0.69535   0.72928   0.73535   0.74618
+ Alpha virt. eigenvalues --    0.75664   0.76043   0.77602   0.77996   0.78599
+ Alpha virt. eigenvalues --    0.78767   0.79610   0.80017   0.81661   0.81950
+ Alpha virt. eigenvalues --    0.82700   0.82943   0.84033   0.84670   0.84816
+ Alpha virt. eigenvalues --    0.85284   0.86325   0.88845   0.89015   0.89487
+ Alpha virt. eigenvalues --    0.90751   0.93249   0.94022   0.95240   0.95257
+ Alpha virt. eigenvalues --    0.95929   0.98397   0.99026   1.00620   1.02792
+ Alpha virt. eigenvalues --    1.04665   1.05638   1.05934   1.06791   1.08841
+ Alpha virt. eigenvalues --    1.10496   1.13141   1.14300   1.14947   1.15450
+ Alpha virt. eigenvalues --    1.17252   1.18726   1.19906   1.22003   1.24242
+ Alpha virt. eigenvalues --    1.29541   1.30081   1.33843   1.34854   1.35487
+ Alpha virt. eigenvalues --    1.36842   1.38393   1.40819   1.41527   1.41973
+ Alpha virt. eigenvalues --    1.43518   1.45068   1.46558   1.49772   1.50499
+ Alpha virt. eigenvalues --    1.51697   1.52075   1.53399   1.54405   1.55755
+ Alpha virt. eigenvalues --    1.56780   1.57099   1.58180   1.59454   1.61239
+ Alpha virt. eigenvalues --    1.62007   1.62466   1.64392   1.65303   1.66783
+ Alpha virt. eigenvalues --    1.69363   1.70689   1.71676   1.73257   1.76085
+ Alpha virt. eigenvalues --    1.76280   1.78589   1.79252   1.80595   1.82538
+ Alpha virt. eigenvalues --    1.84460   1.84974   1.87509   1.88023   1.89251
+ Alpha virt. eigenvalues --    1.90101   1.90591   1.91350   1.95541   1.96898
+ Alpha virt. eigenvalues --    1.97728   1.98458   2.00419   2.01316   2.01533
+ Alpha virt. eigenvalues --    2.03582   2.04378   2.06081   2.06936   2.08951
+ Alpha virt. eigenvalues --    2.09677   2.11265   2.12917   2.13063   2.15075
+ Alpha virt. eigenvalues --    2.16028   2.17850   2.20245   2.20953   2.21772
+ Alpha virt. eigenvalues --    2.22719   2.24104   2.25343   2.26126   2.28836
+ Alpha virt. eigenvalues --    2.30726   2.30850   2.32936   2.34783   2.39269
+ Alpha virt. eigenvalues --    2.41518   2.43643   2.43949   2.44576   2.45043
+ Alpha virt. eigenvalues --    2.49816   2.54873   2.56481   2.61978   2.64763
+ Alpha virt. eigenvalues --    2.66860   2.68962   2.71959   2.72572   2.75668
+ Alpha virt. eigenvalues --    2.76492   2.82458   2.83360   2.84840   2.88878
+ Alpha virt. eigenvalues --    2.90963   2.92420   3.00554   3.03519   3.06497
+ Alpha virt. eigenvalues --    3.11056   3.11595   3.18017   3.19962   3.21159
+ Alpha virt. eigenvalues --    3.25970   3.43899   3.53439   3.55940   3.56144
+ Alpha virt. eigenvalues --    3.56782   3.57294   3.58762   3.60423   3.62160
+ Alpha virt. eigenvalues --    3.65054   3.68597   3.70085   3.75326   3.78417
+ Alpha virt. eigenvalues --    3.93024   3.94216   3.98223   4.18371   4.22111
+ Alpha virt. eigenvalues --    4.38557   4.66182
+          Condensed to atoms (all electrons):
+               1          2          3          4          5          6
+     1  C   16.482807  -2.571965  -2.646342  -5.724782   0.377685   0.060888
+     2  C   -2.571965  11.472832  -2.029618  -0.872267  -0.510212  -0.243582
+     3  C   -2.646342  -2.029618  19.955032  -1.690763   0.310451  -0.080415
+     4  C   -5.724782  -0.872267  -1.690763  21.247321  -0.151581   0.207928
+     5  O    0.377685  -0.510212   0.310451  -0.151581   9.155479  -0.107744
+     6  O    0.060888  -0.243582  -0.080415   0.207928  -0.107744   8.680207
+     7  H   -0.194299   0.155991   0.066699  -0.108713   0.236516  -0.081280
+     8  H    0.004447  -0.071078  -0.032741   0.115753  -0.002807   0.308233
+     9  C    1.209156  -0.294079  -5.017791  -4.716222  -0.154755  -0.062850
+    10  H    0.705254  -0.046965  -1.179635   0.025563  -0.082282   0.010945
+    11  C   -4.271059   0.051161   1.737360   1.931780  -0.019508   0.005862
+    12  H   -0.388316   0.000420   0.696521   0.017718   0.000895  -0.000121
+    13  N    0.116189   0.001231  -0.099125  -0.105703  -0.000039  -0.000421
+    14  C    0.177604  -0.032220  -4.343608  -3.370346  -0.033553  -0.013293
+    15  H   -0.004963  -0.001689  -0.018663   0.079840   0.000083  -0.000010
+    16  H   -0.010614  -0.001062   0.090228  -0.006667   0.000017   0.000044
+    17  H   -0.434057   0.012064   0.047415   0.534213   0.000090  -0.000452
+    18  H    1.368410   0.049666   0.180756  -1.635662   0.009536   0.007708
+    19  O    0.006378  -0.027581   0.033152  -0.021353  -0.066620  -0.027750
+    20  H    0.004436  -0.013268   0.005583  -0.003895   0.005921  -0.000953
+    21  H   -0.005169   0.004859   0.001212   0.000228  -0.000329   0.000834
+               7          8          9         10         11         12
+     1  C   -0.194299   0.004447   1.209156   0.705254  -4.271059  -0.388316
+     2  C    0.155991  -0.071078  -0.294079  -0.046965   0.051161   0.000420
+     3  C    0.066699  -0.032741  -5.017791  -1.179635   1.737360   0.696521
+     4  C   -0.108713   0.115753  -4.716222   0.025563   1.931780   0.017718
+     5  O    0.236516  -0.002807  -0.154755  -0.082282  -0.019508   0.000895
+     6  O   -0.081280   0.308233  -0.062850   0.010945   0.005862  -0.000121
+     7  H    0.419545   0.001100   0.056551  -0.000999  -0.002703   0.000071
+     8  H    0.001100   0.476856  -0.014952   0.000925   0.010138   0.000176
+     9  C    0.056551  -0.014952  15.720553   0.626964  -3.033123  -1.285586
+    10  H   -0.000999   0.000925   0.626964   1.904191  -0.334673  -0.110801
+    11  C   -0.002703   0.010138  -3.033123  -0.334673  12.545392   0.780303
+    12  H    0.000071   0.000176  -1.285586  -0.110801   0.780303   1.883625
+    13  N    0.000174  -0.000508   0.129994   0.002767  -0.024828  -0.094265
+    14  C   -0.007224  -0.002380   1.768422   0.083947  -3.514738   0.046384
+    15  H   -0.000042   0.000103  -0.183947  -0.002026  -0.194296   0.005948
+    16  H   -0.000023   0.000010   0.213726   0.001776  -0.174257   0.012925
+    17  H    0.000068   0.000307   0.051704   0.009272   0.915034  -0.019196
+    18  H    0.000931  -0.024389   0.124593  -0.017597  -0.539241   0.008941
+    19  O   -0.099651   0.005827   0.002475   0.003821   0.000984  -0.000215
+    20  H   -0.001151   0.000230   0.001515   0.000042   0.000395   0.000003
+    21  H   -0.000680   0.000437  -0.000002  -0.000113  -0.000062  -0.000004
+              13         14         15         16         17         18
+     1  C    0.116189   0.177604  -0.004963  -0.010614  -0.434057   1.368410
+     2  C    0.001231  -0.032220  -0.001689  -0.001062   0.012064   0.049666
+     3  C   -0.099125  -4.343608  -0.018663   0.090228   0.047415   0.180756
+     4  C   -0.105703  -3.370346   0.079840  -0.006667   0.534213  -1.635662
+     5  O   -0.000039  -0.033553   0.000083   0.000017   0.000090   0.009536
+     6  O   -0.000421  -0.013293  -0.000010   0.000044  -0.000452   0.007708
+     7  H    0.000174  -0.007224  -0.000042  -0.000023   0.000068   0.000931
+     8  H   -0.000508  -0.002380   0.000103   0.000010   0.000307  -0.024389
+     9  C    0.129994   1.768422  -0.183947   0.213726   0.051704   0.124593
+    10  H    0.002767   0.083947  -0.002026   0.001776   0.009272  -0.017597
+    11  C   -0.024828  -3.514738  -0.194296  -0.174257   0.915034  -0.539241
+    12  H   -0.094265   0.046384   0.005948   0.012925  -0.019196   0.008941
+    13  N    6.487098   0.156971   0.438100   0.437204  -0.103091   0.010068
+    14  C    0.156971  15.367336   0.240671  -0.192177  -1.222026   0.234062
+    15  H    0.438100   0.240671   0.783132  -0.154927   0.014771   0.001165
+    16  H    0.437204  -0.192177  -0.154927   0.779414   0.006398  -0.002411
+    17  H   -0.103091  -1.222026   0.014771   0.006398   1.879770  -0.129187
+    18  H    0.010068   0.234062   0.001165  -0.002411  -0.129187   1.996207
+    19  O   -0.000002  -0.004286   0.000001   0.000004  -0.000006  -0.000647
+    20  H   -0.000006  -0.001004   0.000000   0.000000   0.000003  -0.000094
+    21  H    0.000003   0.000244   0.000000   0.000000  -0.000004  -0.000073
+              19         20         21
+     1  C    0.006378   0.004436  -0.005169
+     2  C   -0.027581  -0.013268   0.004859
+     3  C    0.033152   0.005583   0.001212
+     4  C   -0.021353  -0.003895   0.000228
+     5  O   -0.066620   0.005921  -0.000329
+     6  O   -0.027750  -0.000953   0.000834
+     7  H   -0.099651  -0.001151  -0.000680
+     8  H    0.005827   0.000230   0.000437
+     9  C    0.002475   0.001515  -0.000002
+    10  H    0.003821   0.000042  -0.000113
+    11  C    0.000984   0.000395  -0.000062
+    12  H   -0.000215   0.000003  -0.000004
+    13  N   -0.000002  -0.000006   0.000003
+    14  C   -0.004286  -0.001004   0.000244
+    15  H    0.000001   0.000000   0.000000
+    16  H    0.000004   0.000000   0.000000
+    17  H   -0.000006   0.000003  -0.000004
+    18  H   -0.000647  -0.000094  -0.000073
+    19  O    7.890182   0.377450   0.378225
+    20  H    0.377450   0.452433  -0.038131
+    21  H    0.378225  -0.038131   0.471246
+ Mulliken charges:
+               1
+     1  C    1.738310
+     2  C    0.967362
+     3  C    0.014290
+     4  C    0.247612
+     5  O   -0.967243
+     6  O   -0.663779
+     7  H    0.559118
+     8  H    0.224314
+     9  C    0.857653
+    10  H   -0.600376
+    11  C    0.130079
+    12  H   -0.555425
+    13  N   -0.351810
+    14  C    0.661212
+    15  H   -0.003250
+    16  H    0.000391
+    17  H   -0.563091
+    18  H   -0.642742
+    19  O   -0.450389
+    20  H    0.210487
+    21  H    0.187278
+ Sum of Mulliken charges =   1.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  C    1.738310
+     2  C    0.967362
+     3  C   -0.586086
+     4  C   -0.395131
+     5  O   -0.408125
+     6  O   -0.439465
+     9  C    0.302228
+    11  C    0.130079
+    13  N   -0.354669
+    14  C    0.098121
+    19  O   -0.052623
+ APT charges:
+               1
+     1  C   -0.886902
+     2  C    1.970485
+     3  C    0.295983
+     4  C    0.303668
+     5  O   -1.127998
+     6  O   -0.780937
+     7  H    0.847240
+     8  H    0.320559
+     9  C   -0.286601
+    10  H    0.092441
+    11  C    0.936274
+    12  H    0.062773
+    13  N   -0.972866
+    14  C   -0.297512
+    15  H    0.253640
+    16  H    0.251914
+    17  H    0.063042
+    18  H    0.049504
+    19  O   -0.704505
+    20  H    0.307578
+    21  H    0.302221
+ Sum of APT charges =   1.00000
+ APT charges with hydrogens summed into heavy atoms:
+               1
+     1  C   -0.886902
+     2  C    1.970485
+     3  C    0.388424
+     4  C    0.353172
+     5  O   -0.280758
+     6  O   -0.460378
+     9  C   -0.223828
+    11  C    0.936274
+    13  N   -0.467312
+    14  C   -0.234470
+    19  O   -0.094706
+ Electronic spatial extent (au):  <R**2>=           2578.9153
+ Charge=              1.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=             -1.5139    Y=              1.0192    Z=              0.6177  Tot=              1.9268
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             13.6619   YY=            -45.7235   ZZ=            -68.3291
+   XY=              1.6136   XZ=             -4.0731   YZ=              0.7423
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             47.1255   YY=            -12.2599   ZZ=            -34.8655
+   XY=              1.6136   XZ=             -4.0731   YZ=              0.7423
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=           -123.9000  YYY=              9.7406  ZZZ=              0.4552  XYY=             -9.4923
+  XXY=            -38.2419  XXZ=             18.6958  XZZ=            -22.5855  YZZ=              0.2763
+  YYZ=             -1.4075  XYZ=             -4.7777
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=           -461.8105 YYYY=           -337.9156 ZZZZ=            -72.3253 XXXY=            157.2760
+ XXXZ=           -111.9436 YYYX=             -8.9998 YYYZ=              0.2610 ZZZX=             -2.1917
+ ZZZY=              0.7373 XXYY=           -350.3914 XXZZ=           -481.4996 YYZZ=            -92.3623
+ XXYZ=             24.5434 YYXZ=              4.5446 ZZXY=              1.3488
+ N-N= 5.900581346706D+02 E-N=-2.457137180229D+03  KE= 5.488367318002D+02
+  Exact polarizability:     209.333      -5.228     106.099      -1.347      -0.038      62.189
+ Approx polarizability:     138.663      -2.150      97.889      -0.980       0.256      66.339
+ No NMR shielding tensors so no spin-rotation constants.
+ Leave Link  601 at Mon Oct 16 01:26:35 2023, MaxMem=174483046400 cpu:               4.5 elap:               0.2
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l701.exe)
+ ... and contract with generalized density number  2.
+ Compute integral second derivatives.
+ Leave Link  701 at Mon Oct 16 01:26:36 2023, MaxMem=174483046400 cpu:               6.9 elap:               0.2
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Oct 16 01:26:37 2023, MaxMem=174483046400 cpu:               0.7 elap:               0.0
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l703.exe)
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Compute integral second derivatives, UseDBF=F ICtDFT=           0.
+ Calling FoFJK, ICntrl=  10100127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=10100127 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         0 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=  10100127 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Mon Oct 16 01:27:04 2023, MaxMem=174483046400 cpu:             845.5 elap:              26.5
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l716.exe)
+ Dipole        =-5.23536104D-01 3.39994111D-01 2.25442225D-01
+ Polarizability= 2.09333243D+02-5.22831209D+00 1.06099350D+02
+                -1.34720782D+00-3.78886725D-02 6.21893338D+01
+ Full mass-weighted force constant matrix:
+ Low frequencies ---   -8.0187   -0.0058    0.0008    0.0016    0.8998    3.0911
+ Low frequencies ---   42.7781   50.7917   57.1978
+ Diagonal vibrational polarizability:
+      105.2735163     371.3746506     284.0815376
+ Harmonic frequencies (cm**-1), IR intensities (KM/Mole), Raman scattering
+ activities (A**4/AMU), depolarization ratios for plane and unpolarized
+ incident light, reduced masses (AMU), force constants (mDyne/A),
+ and normal coordinates:
+                      1                      2                      3
+                      A                      A                      A
+ Frequencies --     42.7693                50.7911                57.1921
+ Red. masses --      1.2304                 4.0734                 3.0724
+ Frc consts  --      0.0013                 0.0062                 0.0059
+ IR Inten    --     22.7339                 8.9564                10.1611
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.00  -0.01  -0.02     0.00   0.00  -0.12    -0.00  -0.02   0.01
+     2   6    -0.00  -0.02  -0.03     0.00   0.01  -0.13    -0.00  -0.04   0.02
+     3   6     0.01  -0.01  -0.05     0.00   0.00  -0.10     0.01  -0.01   0.10
+     4   6    -0.01  -0.00   0.03     0.01   0.00  -0.08    -0.02  -0.01  -0.11
+     5   8     0.00  -0.01  -0.00     0.00   0.00  -0.23     0.00  -0.05  -0.19
+     6   8    -0.01  -0.02  -0.06     0.01   0.01  -0.02    -0.01  -0.04   0.22
+     7   1     0.00  -0.01   0.00    -0.00   0.00  -0.08     0.00  -0.02  -0.11
+     8   1    -0.01  -0.02  -0.10     0.01   0.02   0.11    -0.01  -0.02   0.50
+     9   6     0.01   0.00  -0.04     0.00  -0.00  -0.01     0.02   0.00   0.11
+    10   1     0.01  -0.01  -0.09    -0.00   0.00  -0.14     0.03  -0.02   0.19
+    11   6     0.00   0.01   0.01     0.01  -0.00   0.07     0.00   0.01  -0.00
+    12   1     0.01   0.00  -0.07    -0.00  -0.00   0.02     0.03   0.01   0.21
+    13   7     0.00   0.01   0.03     0.01  -0.01   0.19     0.00   0.03  -0.00
+    14   6    -0.01   0.00   0.05     0.01  -0.00   0.00    -0.02   0.01  -0.13
+    15   1    -0.00   0.02   0.07     0.01  -0.01   0.24    -0.01   0.04  -0.09
+    16   1     0.01   0.02   0.01     0.00  -0.01   0.23     0.02   0.04   0.07
+    17   1    -0.01   0.01   0.09     0.01  -0.00   0.03    -0.03   0.01  -0.25
+    18   1    -0.01  -0.01   0.07     0.01   0.00  -0.14    -0.03  -0.02  -0.25
+    19   8     0.00   0.01   0.05    -0.04  -0.00   0.28     0.01   0.07  -0.05
+    20   1    -0.10  -0.00   0.70    -0.00   0.01  -0.02    -0.10   0.11   0.29
+    21   1     0.12   0.51  -0.41     0.02  -0.33   0.71     0.12   0.38  -0.30
+                      4                      5                      6
+                      A                      A                      A
+ Frequencies --     72.5510               112.3176               181.7009
+ Red. masses --      3.9903                 5.8603                 5.0152
+ Frc consts  --      0.0124                 0.0436                 0.0976
+ IR Inten    --      1.0122                 0.4644                 8.6561
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.01  -0.09  -0.01    -0.01   0.00  -0.15    -0.02   0.14  -0.00
+     2   6    -0.01  -0.13  -0.01    -0.00   0.00   0.08    -0.02   0.03  -0.01
+     3   6     0.05  -0.06  -0.02    -0.01   0.00  -0.21    -0.10   0.11   0.00
+     4   6    -0.06  -0.05   0.01    -0.00   0.00  -0.20     0.01   0.11   0.00
+     5   8    -0.00  -0.13   0.07     0.01   0.00   0.26     0.15  -0.08  -0.02
+     6   8    -0.03  -0.14  -0.07    -0.01   0.00   0.19    -0.19  -0.07  -0.01
+     7   1     0.00  -0.09   0.04     0.01  -0.00   0.22     0.11  -0.19  -0.02
+     8   1    -0.05  -0.14  -0.16    -0.02   0.00   0.02    -0.29   0.02  -0.00
+     9   6     0.06   0.01  -0.02    -0.01  -0.00  -0.17    -0.12   0.02   0.01
+    10   1     0.09  -0.09  -0.04    -0.01   0.00  -0.26    -0.16   0.15   0.00
+    11   6     0.00   0.05   0.00    -0.01  -0.00  -0.01    -0.07  -0.03   0.01
+    12   1     0.10   0.03  -0.04    -0.01  -0.00  -0.18    -0.18  -0.00   0.01
+    13   7     0.01   0.12   0.01    -0.00  -0.00   0.31    -0.08  -0.15  -0.01
+    14   6    -0.06   0.02   0.02    -0.00  -0.00  -0.16     0.01   0.02   0.01
+    15   1    -0.03   0.15   0.02     0.00  -0.01   0.38     0.00  -0.22  -0.01
+    16   1     0.06   0.14  -0.00    -0.00  -0.01   0.38    -0.18  -0.20  -0.01
+    17   1    -0.10   0.05   0.05    -0.00  -0.00  -0.17     0.07  -0.03   0.02
+    18   1    -0.11  -0.07   0.04    -0.00   0.00  -0.25     0.04   0.12   0.00
+    19   8     0.05   0.32   0.02     0.04  -0.01  -0.09     0.34  -0.00   0.01
+    20   1    -0.11   0.50  -0.41     0.06  -0.02  -0.10     0.22   0.08   0.02
+    21   1     0.19   0.11   0.38    -0.06   0.06  -0.25     0.52   0.01   0.16
+                      7                      8                      9
+                      A                      A                      A
+ Frequencies --    259.3716               264.0986               282.9740
+ Red. masses --      3.7654                 3.9721                 1.3146
+ Frc consts  --      0.1492                 0.1632                 0.0620
+ IR Inten    --     32.6887                22.9044               167.0337
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.04  -0.11  -0.03    -0.00  -0.01   0.25     0.00   0.00   0.09
+     2   6    -0.01   0.01  -0.02    -0.00   0.00   0.08     0.00   0.00   0.03
+     3   6    -0.03  -0.11  -0.01    -0.00  -0.01   0.10    -0.00   0.00   0.04
+     4   6    -0.09  -0.09  -0.01    -0.01  -0.01   0.10    -0.00   0.00   0.03
+     5   8    -0.08   0.09  -0.00    -0.01   0.01  -0.08    -0.00  -0.00  -0.03
+     6   8     0.15   0.11   0.01     0.02   0.01  -0.09     0.00   0.00  -0.03
+     7   1    -0.11   0.13  -0.01    -0.02   0.01  -0.12    -0.00  -0.00  -0.04
+     8   1     0.27   0.02  -0.01     0.04   0.00   0.06     0.01  -0.00   0.02
+     9   6    -0.02  -0.06   0.03    -0.01  -0.01  -0.19    -0.00  -0.00  -0.07
+    10   1    -0.02  -0.12  -0.02    -0.00  -0.01   0.13    -0.00   0.00   0.04
+    11   6    -0.08  -0.01   0.02    -0.01  -0.00  -0.14    -0.00   0.00  -0.01
+    12   1     0.03  -0.03   0.05    -0.00  -0.00  -0.31    -0.00  -0.00  -0.12
+    13   7    -0.07   0.13  -0.03    -0.01   0.01   0.25    -0.00  -0.00  -0.07
+    14   6    -0.11  -0.03   0.02    -0.01  -0.00  -0.18    -0.00  -0.00  -0.06
+    15   1    -0.17   0.20   0.02    -0.02   0.01  -0.48     0.01   0.01   0.69
+    16   1     0.04   0.18   0.02    -0.01   0.01  -0.47     0.01   0.00   0.67
+    17   1    -0.13  -0.02   0.04    -0.01  -0.00  -0.29    -0.00  -0.00  -0.12
+    18   1    -0.12  -0.10  -0.01    -0.01  -0.01   0.13     0.00   0.00   0.03
+    19   8     0.25  -0.02  -0.02     0.02   0.00  -0.01     0.00   0.00  -0.00
+    20   1     0.48  -0.23   0.28     0.06  -0.04   0.13     0.01  -0.01   0.04
+    21   1     0.29  -0.18   0.20     0.12  -0.06   0.15     0.04  -0.02   0.05
+                     10                     11                     12
+                      A                      A                      A
+ Frequencies --    305.9364               372.4495               387.8587
+ Red. masses --      1.3483                 4.5082                 2.9357
+ Frc consts  --      0.0744                 0.3685                 0.2602
+ IR Inten    --    188.9188                31.6812                34.1814
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6     0.00   0.01  -0.02     0.06  -0.02  -0.01     0.05   0.06  -0.00
+     2   6    -0.01  -0.01   0.00     0.12  -0.07   0.00     0.08   0.04   0.00
+     3   6     0.01   0.02  -0.01    -0.01  -0.02  -0.02    -0.06   0.01  -0.06
+     4   6     0.02   0.01  -0.01    -0.07   0.07   0.01     0.04   0.05   0.06
+     5   8    -0.01  -0.01   0.02     0.12  -0.08   0.01     0.16  -0.03   0.01
+     6   8    -0.04  -0.02   0.02     0.26  -0.02   0.01     0.03   0.01   0.01
+     7   1    -0.02   0.01  -0.04     0.13  -0.09  -0.03     0.16  -0.13  -0.06
+     8   1    -0.06  -0.00  -0.05     0.37  -0.12  -0.06    -0.01   0.03  -0.14
+     9   6     0.01   0.01   0.02    -0.05   0.08   0.02    -0.07  -0.14   0.06
+    10   1     0.02   0.01  -0.02    -0.03  -0.01  -0.04    -0.16   0.08  -0.13
+    11   6     0.03   0.00   0.01    -0.14   0.13   0.00    -0.08  -0.12  -0.00
+    12   1     0.01   0.01   0.02     0.07   0.14   0.04    -0.13  -0.16   0.12
+    13   7     0.03  -0.02  -0.01    -0.19  -0.15   0.00    -0.07   0.17   0.00
+    14   6     0.02   0.00   0.01    -0.07   0.17  -0.02    -0.00  -0.09  -0.06
+    15   1     0.04  -0.03  -0.02     0.05  -0.33  -0.02    -0.31   0.35  -0.07
+    16   1     0.01  -0.03  -0.01    -0.46  -0.28   0.03     0.22   0.30   0.08
+    17   1     0.02   0.01   0.01    -0.07   0.17  -0.02     0.11  -0.17  -0.10
+    18   1     0.02   0.01  -0.00    -0.15   0.03   0.05     0.09   0.06   0.18
+    19   8    -0.07   0.05  -0.10    -0.08   0.00  -0.02    -0.08  -0.02  -0.03
+    20   1     0.20  -0.26   0.64    -0.15   0.04   0.09    -0.31   0.15   0.05
+    21   1     0.26  -0.27   0.55     0.07  -0.01   0.13     0.21   0.04   0.18
+                     13                     14                     15
+                      A                      A                      A
+ Frequencies --    392.2581               428.3546               484.2708
+ Red. masses --      2.6672                 1.2702                 1.9886
+ Frc consts  --      0.2418                 0.1373                 0.2748
+ IR Inten    --     12.8271                18.2441                 0.4373
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6     0.02   0.02   0.01    -0.03  -0.02  -0.00    -0.00   0.01   0.13
+     2   6     0.04   0.01   0.00    -0.04   0.02   0.00    -0.00  -0.00   0.07
+     3   6    -0.02   0.00   0.17     0.01  -0.01   0.01    -0.00   0.01  -0.14
+     4   6     0.01   0.02  -0.19    -0.01  -0.03  -0.02     0.00   0.00  -0.04
+     5   8     0.06  -0.02   0.01    -0.03   0.02   0.02    -0.01  -0.00   0.02
+     6   8     0.02  -0.01  -0.02     0.01   0.05   0.01     0.01  -0.00  -0.08
+     7   1     0.07  -0.03   0.04    -0.06  -0.14  -0.12    -0.01  -0.00  -0.00
+     8   1     0.02   0.01   0.29     0.05   0.02  -0.04     0.05   0.01   0.63
+     9   6    -0.03  -0.04  -0.17     0.02   0.02  -0.01    -0.00   0.00   0.05
+    10   1    -0.05   0.03   0.37     0.04  -0.03   0.02    -0.01   0.01  -0.46
+    11   6    -0.04  -0.03   0.02     0.03   0.02   0.00     0.00  -0.00   0.17
+    12   1    -0.04  -0.05  -0.33     0.02   0.02  -0.02    -0.01  -0.00  -0.18
+    13   7    -0.04   0.05  -0.01     0.03  -0.02  -0.00     0.00   0.00  -0.05
+    14   6    -0.00  -0.02   0.19    -0.00   0.00   0.02     0.00  -0.00  -0.01
+    15   1    -0.10   0.10   0.19     0.06  -0.04   0.01    -0.00   0.00  -0.08
+    16   1     0.04   0.09  -0.24    -0.00  -0.03  -0.02     0.00   0.00  -0.16
+    17   1     0.04  -0.05   0.28    -0.03   0.02   0.02    -0.00  -0.00  -0.32
+    18   1     0.02   0.03  -0.53    -0.01  -0.03  -0.05     0.01   0.01  -0.37
+    19   8    -0.03   0.01  -0.01     0.00  -0.08  -0.02     0.00  -0.00  -0.00
+    20   1    -0.01  -0.02   0.06    -0.58   0.36  -0.08    -0.01   0.01   0.00
+    21   1    -0.01  -0.02   0.05     0.60   0.15   0.25     0.02   0.00   0.01
+                     16                     17                     18
+                      A                      A                      A
+ Frequencies --    491.9763               514.3668               536.4887
+ Red. masses --      1.0394                 4.4644                 1.4032
+ Frc consts  --      0.1482                 0.6959                 0.2380
+ IR Inten    --      0.1114                16.7670               130.2648
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.00   0.00   0.01     0.05  -0.15   0.02    -0.00  -0.01  -0.09
+     2   6    -0.00  -0.00   0.00     0.09   0.18   0.00    -0.00   0.01  -0.02
+     3   6    -0.00   0.00   0.01     0.05  -0.22  -0.01    -0.00  -0.01   0.01
+     4   6    -0.00   0.00  -0.02    -0.04  -0.15  -0.00    -0.00  -0.01   0.06
+     5   8    -0.00  -0.00  -0.00     0.22   0.12  -0.01     0.01   0.00   0.05
+     6   8     0.00  -0.00  -0.00    -0.20   0.07  -0.00    -0.00   0.01  -0.07
+     7   1    -0.00  -0.00  -0.00     0.23   0.01   0.00     0.01  -0.02   0.08
+     8   1     0.00   0.00   0.05    -0.48   0.28  -0.02     0.03   0.04   0.91
+     9   6    -0.00  -0.00  -0.03     0.06  -0.01  -0.00     0.00   0.00   0.02
+    10   1    -0.00   0.00  -0.05     0.13  -0.28  -0.05     0.01  -0.01   0.14
+    11   6     0.00  -0.00   0.01    -0.04   0.08   0.02     0.00   0.00  -0.10
+    12   1    -0.00  -0.00  -0.16     0.24   0.07  -0.05     0.01   0.01   0.20
+    13   7     0.00   0.00  -0.00    -0.06  -0.02  -0.00     0.00  -0.00   0.02
+    14   6     0.00  -0.00   0.03    -0.04   0.06  -0.00    -0.00   0.00  -0.01
+    15   1    -0.01  -0.01  -0.69     0.04  -0.10  -0.02     0.01  -0.00   0.05
+    16   1     0.01   0.00   0.69    -0.18  -0.08  -0.01    -0.00  -0.00   0.09
+    17   1     0.00   0.00   0.13    -0.12   0.12  -0.04    -0.01   0.00   0.15
+    18   1     0.00   0.00   0.00    -0.23  -0.24  -0.05     0.00  -0.01   0.19
+    19   8     0.00  -0.00  -0.00    -0.03   0.01  -0.01    -0.00  -0.00  -0.01
+    20   1    -0.00   0.00   0.00    -0.01  -0.01   0.03    -0.04   0.02   0.02
+    21   1     0.00   0.00   0.00    -0.05  -0.02   0.01     0.04  -0.00   0.03
+                     19                     20                     21
+                      A                      A                      A
+ Frequencies --    609.6338               630.3723               669.5092
+ Red. masses --      5.1757                 6.7699                 4.7419
+ Frc consts  --      1.1333                 1.5850                 1.2523
+ IR Inten    --      5.8054                 2.5392                 8.7001
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.18  -0.01   0.01     0.01  -0.08  -0.00    -0.00   0.00  -0.20
+     2   6    -0.10   0.07  -0.00     0.00  -0.03   0.00    -0.00  -0.01  -0.24
+     3   6    -0.14   0.06   0.00    -0.30  -0.16   0.00     0.00   0.00   0.20
+     4   6    -0.12  -0.15   0.00     0.30  -0.20  -0.00     0.01   0.00   0.23
+     5   8     0.22  -0.17  -0.01    -0.06  -0.02  -0.00    -0.00   0.00   0.06
+     6   8     0.07   0.16  -0.00     0.01  -0.06   0.00     0.00   0.00   0.05
+     7   1     0.20  -0.37   0.12    -0.05   0.03  -0.01    -0.01  -0.01   0.09
+     8   1     0.31  -0.02  -0.07     0.02  -0.06  -0.02     0.00   0.01   0.14
+     9   6    -0.10   0.15  -0.00    -0.27   0.19   0.00    -0.00  -0.00  -0.15
+    10   1    -0.01  -0.03  -0.01    -0.24  -0.21   0.01     0.00   0.00   0.01
+    11   6     0.14   0.01   0.01    -0.00   0.09  -0.00     0.00   0.00   0.31
+    12   1    -0.24   0.09  -0.02    -0.17   0.24   0.00    -0.00  -0.00  -0.52
+    13   7     0.19  -0.01  -0.00    -0.01   0.09  -0.00    -0.00   0.00  -0.04
+    14   6    -0.10  -0.10  -0.00     0.33   0.16  -0.00     0.00   0.00  -0.15
+    15   1     0.20  -0.01  -0.00    -0.12   0.17  -0.00    -0.01   0.00  -0.14
+    16   1     0.19  -0.02  -0.01     0.11   0.15  -0.00    -0.00   0.00  -0.11
+    17   1    -0.28   0.03  -0.01     0.28   0.20  -0.00     0.00  -0.00  -0.57
+    18   1    -0.03  -0.11   0.00     0.17  -0.25  -0.00     0.00   0.01  -0.10
+    19   8    -0.03   0.05  -0.00     0.01  -0.00   0.00    -0.00  -0.00  -0.00
+    20   1     0.19  -0.14   0.08    -0.01   0.01  -0.01    -0.01   0.01   0.00
+    21   1    -0.26  -0.07  -0.07     0.02   0.01   0.00     0.01   0.00   0.00
+                     22                     23                     24
+                      A                      A                      A
+ Frequencies --    757.7497               763.2840               797.1030
+ Red. masses --      5.2309                 5.5775                 1.4256
+ Frc consts  --      1.7696                 1.9145                 0.5337
+ IR Inten    --     20.8369                23.3331                 3.3954
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.05   0.00   0.01    -0.00  -0.00  -0.26     0.00   0.00   0.05
+     2   6    -0.22   0.01  -0.00     0.00   0.01   0.49    -0.00  -0.00  -0.08
+     3   6     0.16  -0.02  -0.00     0.00  -0.00   0.04    -0.00  -0.00   0.07
+     4   6     0.15  -0.02  -0.00    -0.00  -0.00  -0.04    -0.00   0.00  -0.12
+     5   8    -0.02  -0.24  -0.00    -0.00  -0.00  -0.11    -0.00   0.00   0.02
+     6   8    -0.06   0.26  -0.01    -0.00   0.00  -0.10    -0.00  -0.00   0.01
+     7   1    -0.07  -0.41   0.13    -0.00   0.01  -0.07    -0.00  -0.00   0.02
+     8   1     0.32  -0.03  -0.03     0.02  -0.01  -0.06    -0.00   0.01   0.11
+     9   6     0.14  -0.09   0.00     0.00  -0.00  -0.09    -0.00  -0.00   0.04
+    10   1     0.22  -0.07  -0.01     0.01  -0.00   0.30    -0.01  -0.00  -0.37
+    11   6    -0.09   0.01  -0.00     0.00   0.00   0.23     0.00  -0.00   0.04
+    12   1     0.28  -0.03  -0.01     0.01  -0.00   0.10    -0.00  -0.00  -0.34
+    13   7    -0.19   0.02   0.00    -0.00  -0.00  -0.04     0.00  -0.00  -0.01
+    14   6     0.16   0.06  -0.00    -0.00  -0.00  -0.11     0.00   0.00  -0.07
+    15   1    -0.20   0.02   0.00    -0.00  -0.00  -0.07     0.00   0.00   0.09
+    16   1    -0.19   0.02   0.00    -0.00  -0.00  -0.13     0.00  -0.00  -0.12
+    17   1     0.28  -0.03  -0.00     0.00   0.00   0.30     0.01   0.00   0.47
+    18   1     0.23   0.02  -0.00     0.00  -0.00   0.61     0.00   0.00   0.67
+    19   8     0.00   0.02   0.00     0.00  -0.00   0.00    -0.00  -0.00  -0.00
+    20   1     0.11  -0.07   0.03    -0.00   0.00  -0.00    -0.00   0.00   0.00
+    21   1    -0.12  -0.03  -0.04     0.00  -0.00   0.00     0.00  -0.00   0.00
+                     25                     26                     27
+                      A                      A                      A
+ Frequencies --    839.9850               851.9726               908.5679
+ Red. masses --      1.7833                 5.8406                 1.2027
+ Frc consts  --      0.7413                 2.4978                 0.5850
+ IR Inten    --     24.5182                 3.9324                 0.2955
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6     0.00   0.00   0.12     0.06  -0.01  -0.00    -0.00   0.00  -0.00
+     2   6    -0.00  -0.00  -0.10    -0.04  -0.00   0.00     0.00   0.00   0.02
+     3   6    -0.00  -0.00  -0.10    -0.15  -0.29   0.00    -0.00  -0.00   0.04
+     4   6    -0.00   0.00  -0.03    -0.10   0.31   0.00     0.00   0.00   0.08
+     5   8     0.00   0.00   0.02    -0.03  -0.08  -0.00    -0.00  -0.00  -0.00
+     6   8     0.00   0.00   0.02    -0.02   0.09  -0.00     0.00   0.00  -0.00
+     7   1     0.00  -0.00   0.00    -0.04  -0.11   0.05     0.00   0.00  -0.01
+     8   1    -0.00   0.00   0.04     0.08   0.01   0.00    -0.00  -0.00  -0.05
+     9   6    -0.00  -0.00  -0.12    -0.04  -0.26   0.00     0.00  -0.00  -0.01
+    10   1     0.00   0.00   0.54    -0.37  -0.15   0.00    -0.00  -0.00  -0.37
+    11   6     0.00   0.00   0.13     0.05  -0.00  -0.00     0.00   0.00  -0.01
+    12   1     0.01   0.00   0.72     0.08  -0.22  -0.01     0.00   0.00   0.15
+    13   7     0.00  -0.00  -0.02     0.23  -0.02  -0.00     0.00   0.00  -0.00
+    14   6    -0.00   0.00  -0.06     0.01   0.26   0.00    -0.00   0.00  -0.10
+    15   1    -0.00  -0.00  -0.10     0.27  -0.04  -0.00     0.00  -0.00   0.02
+    16   1     0.00  -0.00  -0.01     0.25  -0.02   0.00    -0.00  -0.00  -0.02
+    17   1     0.00   0.00   0.30     0.10   0.21  -0.03     0.01   0.00   0.70
+    18   1    -0.00   0.00   0.14    -0.27   0.26  -0.01    -0.00   0.00  -0.58
+    19   8    -0.00   0.00   0.00     0.00   0.00   0.00     0.00   0.00   0.00
+    20   1     0.00  -0.00   0.00     0.03  -0.01   0.01     0.00  -0.00  -0.00
+    21   1    -0.00  -0.00  -0.00    -0.02  -0.01  -0.01    -0.00   0.00  -0.00
+                     28                     29                     30
+                      A                      A                      A
+ Frequencies --    948.7958               999.8554              1032.2671
+ Red. masses --      1.2956                 2.8828                 1.0611
+ Frc consts  --      0.6872                 1.6980                 0.6662
+ IR Inten    --      0.3059                 2.0909                91.7349
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.00  -0.00   0.01     0.05  -0.01  -0.00     0.00  -0.00   0.01
+     2   6    -0.00  -0.00  -0.01     0.00  -0.01   0.00    -0.00   0.00   0.00
+     3   6    -0.00  -0.00  -0.10    -0.04  -0.19   0.00     0.00   0.00  -0.00
+     4   6     0.00  -0.00   0.04     0.00   0.19  -0.00    -0.00  -0.00   0.00
+     5   8     0.00   0.00   0.00    -0.01  -0.02  -0.00    -0.00   0.02  -0.05
+     6   8     0.00  -0.00   0.00    -0.01   0.02  -0.00     0.01  -0.01  -0.01
+     7   1    -0.00  -0.00   0.01    -0.01  -0.01   0.03    -0.04  -0.05   0.99
+     8   1    -0.00   0.00  -0.01     0.01   0.01  -0.00    -0.01  -0.00  -0.05
+     9   6     0.00   0.00   0.10     0.00   0.21  -0.00    -0.00   0.00  -0.00
+    10   1     0.01   0.00   0.67     0.20  -0.36   0.00    -0.00   0.01  -0.01
+    11   6     0.00  -0.00   0.01     0.00   0.00   0.00    -0.00  -0.00   0.00
+    12   1    -0.01  -0.00  -0.64     0.32   0.37  -0.01    -0.00   0.00   0.01
+    13   7     0.00  -0.00   0.00    -0.02   0.00   0.00     0.00  -0.00  -0.00
+    14   6    -0.00   0.00  -0.06    -0.04  -0.21   0.00     0.00   0.00  -0.00
+    15   1     0.00   0.00   0.02    -0.03   0.01   0.00    -0.01   0.01  -0.00
+    16   1     0.00  -0.00  -0.02    -0.04  -0.00   0.00     0.01   0.00   0.00
+    17   1     0.00   0.00   0.31     0.24  -0.42   0.00     0.00   0.00  -0.00
+    18   1    -0.00  -0.00  -0.14     0.29   0.32  -0.00    -0.01  -0.00  -0.00
+    19   8    -0.00  -0.00  -0.00     0.00  -0.00  -0.00     0.00  -0.01  -0.02
+    20   1    -0.00   0.00   0.00     0.00  -0.00   0.00    -0.09   0.05   0.03
+    21   1     0.00  -0.00   0.00     0.00  -0.00   0.00     0.05  -0.02   0.04
+                     31                     32                     33
+                      A                      A                      A
+ Frequencies --   1042.4560              1134.6481              1157.6573
+ Red. masses --      1.4201                 2.6974                 1.2043
+ Frc consts  --      0.9092                 2.0461                 0.9509
+ IR Inten    --      0.3917                25.9863                 8.1717
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.00  -0.03  -0.00     0.20  -0.04  -0.00     0.04   0.05  -0.00
+     2   6     0.00  -0.00   0.00     0.14  -0.06   0.00     0.01   0.00  -0.00
+     3   6     0.04   0.01  -0.00     0.02   0.05  -0.00    -0.05  -0.02   0.00
+     4   6    -0.04   0.02   0.00     0.01  -0.02   0.00     0.04  -0.04  -0.00
+     5   8     0.00   0.00   0.00    -0.10  -0.15   0.00    -0.01  -0.01   0.00
+     6   8    -0.00   0.01  -0.00    -0.02   0.15  -0.01    -0.01   0.01   0.00
+     7   1     0.00   0.00  -0.03    -0.07   0.08   0.06    -0.01   0.00   0.01
+     8   1    -0.03   0.03   0.00    -0.51   0.53   0.00     0.04  -0.03  -0.00
+     9   6    -0.00   0.07  -0.00    -0.06   0.06   0.00     0.04  -0.01  -0.00
+    10   1     0.18  -0.08  -0.00    -0.18   0.20  -0.00    -0.47   0.28   0.00
+    11   6    -0.01  -0.07   0.00     0.01  -0.01   0.00     0.00   0.03  -0.00
+    12   1     0.02   0.09  -0.00    -0.29  -0.03   0.00     0.54   0.21  -0.01
+    13   7    -0.01  -0.12   0.00     0.01   0.01  -0.00    -0.00  -0.03   0.00
+    14   6     0.01   0.07  -0.00    -0.05  -0.04   0.00    -0.05  -0.03   0.00
+    15   1    -0.58   0.31   0.00     0.05  -0.02  -0.00    -0.13   0.06   0.00
+    16   1     0.63   0.19  -0.01    -0.05  -0.02   0.00     0.14   0.03  -0.00
+    17   1    -0.01   0.10   0.00    -0.07  -0.03   0.00    -0.42   0.23   0.00
+    18   1    -0.18  -0.03  -0.00    -0.33  -0.18   0.00     0.27   0.05  -0.00
+    19   8    -0.00   0.00   0.00     0.00  -0.00  -0.00    -0.00  -0.00  -0.00
+    20   1     0.00  -0.00  -0.00    -0.00   0.00  -0.01    -0.00  -0.00  -0.00
+    21   1    -0.00   0.00  -0.00     0.02   0.01   0.00     0.00   0.00   0.00
+                     34                     35                     36
+                      A                      A                      A
+ Frequencies --   1206.6712              1227.4626              1331.3986
+ Red. masses --      1.1228                 1.5806                 1.3130
+ Frc consts  --      0.9632                 1.4031                 1.3713
+ IR Inten    --    216.2907               127.6879                 4.2616
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6     0.00  -0.01  -0.00     0.15  -0.04  -0.00    -0.04  -0.12   0.00
+     2   6    -0.03   0.01   0.00    -0.00  -0.05  -0.00    -0.00   0.00   0.00
+     3   6    -0.02   0.03   0.00     0.03   0.01  -0.00     0.04  -0.02  -0.00
+     4   6    -0.05  -0.02   0.00    -0.00  -0.00   0.00    -0.04   0.01   0.00
+     5   8     0.01   0.01   0.00     0.02   0.04  -0.00     0.01   0.01  -0.00
+     6   8     0.01  -0.01   0.00    -0.11   0.04   0.00     0.00  -0.00  -0.00
+     7   1    -0.01  -0.07  -0.02     0.00   0.05   0.01     0.00  -0.06  -0.01
+     8   1     0.02  -0.02   0.00     0.71  -0.59  -0.00    -0.10   0.08  -0.00
+     9   6     0.03   0.01  -0.00    -0.03   0.04   0.00     0.04   0.03  -0.00
+    10   1    -0.33   0.26   0.00    -0.11   0.11  -0.00    -0.46   0.34   0.00
+    11   6    -0.03  -0.00   0.00    -0.01  -0.00   0.00     0.03   0.06  -0.00
+    12   1     0.38   0.17  -0.01    -0.25  -0.06   0.00    -0.40  -0.17   0.01
+    13   7     0.02   0.00  -0.00     0.01  -0.00  -0.00    -0.02  -0.02   0.00
+    14   6     0.04  -0.01  -0.00    -0.03  -0.01   0.00    -0.01   0.03   0.00
+    15   1     0.04  -0.02  -0.00     0.00   0.00   0.00    -0.12   0.05   0.00
+    16   1     0.03   0.01  -0.00     0.00  -0.00   0.00     0.07   0.02  -0.00
+    17   1     0.52  -0.34  -0.00    -0.04  -0.01   0.00     0.27  -0.16  -0.00
+    18   1    -0.46  -0.19   0.00    -0.11  -0.05  -0.00     0.51   0.24  -0.00
+    19   8    -0.00   0.00   0.00    -0.00  -0.00  -0.00     0.00   0.00   0.00
+    20   1     0.01  -0.00   0.00    -0.00  -0.00  -0.00     0.00  -0.00   0.00
+    21   1    -0.01  -0.00  -0.00     0.01   0.00   0.01    -0.01  -0.00  -0.00
+                     37                     38                     39
+                      A                      A                      A
+ Frequencies --   1371.8946              1392.0717              1419.1747
+ Red. masses --      1.7791                 2.5520                 3.1357
+ Frc consts  --      1.9728                 2.9137                 3.7210
+ IR Inten    --    388.6424               893.9394                28.8696
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.08  -0.03   0.00    -0.14   0.03   0.00     0.02   0.26  -0.00
+     2   6     0.11  -0.11  -0.00     0.09  -0.08  -0.00     0.02   0.06  -0.00
+     3   6    -0.01   0.07  -0.00    -0.06  -0.04   0.00    -0.02  -0.11   0.00
+     4   6    -0.02  -0.05   0.00    -0.06   0.05   0.00     0.01  -0.12   0.00
+     5   8     0.01  -0.02  -0.00     0.02  -0.02  -0.00    -0.04  -0.06   0.00
+     6   8    -0.05   0.07  -0.00    -0.03   0.05  -0.00     0.01  -0.02   0.00
+     7   1     0.14   0.60   0.07     0.17   0.65   0.06     0.03   0.26   0.02
+     8   1     0.08  -0.03  -0.00     0.11  -0.07   0.00     0.09  -0.08  -0.00
+     9   6    -0.05  -0.04   0.00     0.09   0.01  -0.00     0.05  -0.06   0.00
+    10   1     0.22  -0.08  -0.00    -0.24   0.06   0.00     0.08  -0.19   0.00
+    11   6    -0.08   0.00   0.00     0.22  -0.03  -0.00     0.01   0.25  -0.00
+    12   1     0.34   0.13  -0.00    -0.07  -0.08   0.00    -0.36  -0.26   0.00
+    13   7     0.06  -0.00  -0.00    -0.13   0.02   0.00     0.00  -0.08   0.00
+    14   6    -0.03   0.06   0.00     0.11  -0.03  -0.00    -0.09  -0.04   0.00
+    15   1     0.15  -0.06  -0.00    -0.25   0.10   0.00    -0.24   0.11   0.00
+    16   1     0.14   0.03  -0.00    -0.29  -0.05   0.00     0.32   0.08  -0.00
+    17   1     0.29  -0.17  -0.00    -0.10   0.13   0.00     0.36  -0.38  -0.00
+    18   1     0.41   0.13  -0.00    -0.36  -0.06   0.00    -0.06  -0.17   0.00
+    19   8    -0.00  -0.01  -0.00    -0.00  -0.01  -0.00     0.00  -0.01  -0.00
+    20   1    -0.04   0.02  -0.02    -0.05   0.03  -0.02    -0.02   0.01  -0.01
+    21   1     0.07   0.01   0.03     0.07   0.01   0.03     0.03   0.01   0.01
+                     40                     41                     42
+                      A                      A                      A
+ Frequencies --   1534.1106              1545.6005              1554.3772
+ Red. masses --      2.2315                 6.6391                 4.3216
+ Frc consts  --      3.0942                 9.3445                 6.1519
+ IR Inten    --    141.0100                43.4619               286.4969
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.05  -0.01   0.00    -0.05   0.11  -0.00     0.13   0.03  -0.00
+     2   6    -0.06   0.16  -0.00    -0.04  -0.10   0.00     0.07   0.31  -0.01
+     3   6     0.08  -0.07  -0.00     0.34  -0.12  -0.00     0.05   0.01  -0.00
+     4   6     0.08   0.03  -0.00    -0.23   0.01   0.00    -0.23  -0.10   0.00
+     5   8    -0.01  -0.09   0.00     0.04   0.04  -0.00    -0.10  -0.12   0.00
+     6   8     0.03  -0.05   0.00     0.01   0.02  -0.00     0.00  -0.07   0.00
+     7   1     0.21   0.75   0.03     0.02   0.11   0.01     0.00   0.06  -0.01
+     8   1     0.05  -0.06   0.00    -0.10   0.10   0.00     0.21  -0.21  -0.00
+     9   6     0.04   0.09  -0.00    -0.32  -0.06   0.00    -0.14  -0.02   0.00
+    10   1    -0.25   0.16   0.00    -0.20   0.29  -0.00     0.13  -0.02  -0.00
+    11   6    -0.15  -0.10   0.00    -0.11   0.19   0.00     0.17  -0.12  -0.00
+    12   1    -0.22  -0.01   0.00     0.08   0.15  -0.00     0.31   0.19  -0.00
+    13   7     0.05   0.02  -0.00     0.04   0.00  -0.00    -0.05   0.04   0.00
+    14   6    -0.02   0.01  -0.00     0.34  -0.19  -0.00     0.05   0.09  -0.00
+    15   1     0.23  -0.12  -0.00     0.11  -0.04  -0.00    -0.13   0.08   0.00
+    16   1     0.10   0.03  -0.00     0.20   0.08  -0.00    -0.33  -0.09   0.00
+    17   1    -0.15   0.10   0.00    -0.36   0.31   0.00     0.25  -0.02  -0.00
+    18   1    -0.16  -0.06   0.00    -0.06   0.11  -0.00     0.47   0.20  -0.00
+    19   8     0.00  -0.01  -0.00    -0.01  -0.00   0.00     0.02  -0.00  -0.00
+    20   1    -0.07   0.04   0.00     0.02  -0.01  -0.02    -0.06   0.04   0.04
+    21   1     0.05  -0.00   0.03     0.03   0.02   0.00    -0.04  -0.04   0.00
+                     43                     44                     45
+                      A                      A                      A
+ Frequencies --   1606.5147              1631.1767              1652.4020
+ Red. masses --      4.8558                 1.1307                 1.6760
+ Frc consts  --      7.3838                 1.7726                 2.6963
+ IR Inten    --    106.8336                21.9860               305.0828
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.07   0.30  -0.00     0.03  -0.00   0.00    -0.04  -0.03   0.00
+     2   6     0.12  -0.15   0.00    -0.04   0.00   0.00     0.13   0.07  -0.00
+     3   6     0.10  -0.19   0.00    -0.01   0.01   0.00    -0.06   0.03   0.00
+     4   6    -0.08  -0.14   0.00    -0.01  -0.01   0.00    -0.05   0.02   0.00
+     5   8    -0.01   0.06  -0.00     0.02  -0.00  -0.00    -0.05  -0.03   0.00
+     6   8    -0.02   0.04  -0.00     0.01  -0.01  -0.00    -0.02  -0.00   0.00
+     7   1    -0.17  -0.55  -0.00    -0.02   0.09   0.06    -0.08  -0.25   0.00
+     8   1    -0.01   0.03  -0.00    -0.03   0.03  -0.00     0.12  -0.11  -0.00
+     9   6     0.07   0.16  -0.00     0.00  -0.00  -0.00     0.07   0.00  -0.00
+    10   1    -0.28   0.05   0.00     0.02  -0.01  -0.00     0.03  -0.04   0.00
+    11   6    -0.06  -0.28   0.00     0.01  -0.00  -0.00    -0.03   0.03   0.00
+    12   1    -0.22   0.05   0.00     0.00  -0.00  -0.00    -0.07  -0.06   0.00
+    13   7     0.01   0.05  -0.00     0.00   0.00  -0.00    -0.08   0.00   0.00
+    14   6    -0.03   0.15  -0.00     0.00   0.00  -0.00     0.08  -0.04  -0.00
+    15   1     0.26  -0.14  -0.00    -0.04   0.03   0.00     0.47  -0.40  -0.00
+    16   1    -0.07   0.00   0.00    -0.05  -0.02   0.00     0.56   0.31  -0.01
+    17   1     0.17   0.02  -0.00     0.01   0.00  -0.00    -0.09   0.08   0.00
+    18   1     0.20  -0.04  -0.00     0.04   0.01  -0.00    -0.02   0.04  -0.00
+    19   8    -0.01   0.01   0.01    -0.07  -0.01   0.02    -0.01   0.00   0.00
+    20   1     0.11  -0.07  -0.05     0.49  -0.32  -0.37     0.10  -0.06  -0.06
+    21   1     0.04   0.06  -0.02     0.54   0.44  -0.00     0.08   0.07  -0.01
+                     46                     47                     48
+                      A                      A                      A
+ Frequencies --   1656.5213              1691.1400              2843.6831
+ Red. masses --      3.8498                 2.6409                 1.0770
+ Frc consts  --      6.2241                 4.4500                 5.1314
+ IR Inten    --   1414.4521               179.7329              4141.7483
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6     0.24   0.05  -0.00     0.03   0.02  -0.00     0.01   0.00  -0.00
+     2   6    -0.23  -0.10   0.00    -0.14  -0.05   0.00    -0.01  -0.01   0.00
+     3   6    -0.17   0.04   0.00     0.08  -0.03  -0.00    -0.00   0.00   0.00
+     4   6    -0.21  -0.08   0.00     0.08   0.00  -0.00    -0.00  -0.00   0.00
+     5   8     0.06   0.02   0.00     0.04   0.03  -0.00    -0.06   0.02  -0.00
+     6   8     0.03   0.01  -0.00     0.03  -0.01  -0.00    -0.00   0.00  -0.00
+     7   1     0.11   0.47  -0.01     0.08   0.20   0.00     0.97  -0.22   0.03
+     8   1    -0.22   0.21  -0.00    -0.10   0.08   0.00    -0.00   0.01  -0.00
+     9   6     0.16   0.04  -0.00    -0.13  -0.02   0.00     0.00   0.00  -0.00
+    10   1     0.13  -0.18   0.00    -0.04   0.06  -0.00    -0.00  -0.00   0.00
+    11   6    -0.06  -0.04   0.00     0.20  -0.03  -0.00    -0.00   0.00   0.00
+    12   1    -0.15  -0.11   0.00     0.13   0.10  -0.00    -0.00   0.00   0.00
+    13   7    -0.04   0.01   0.00    -0.15   0.02   0.00     0.00  -0.00  -0.00
+    14   6     0.13  -0.00  -0.00    -0.13   0.06   0.00     0.00  -0.00  -0.00
+    15   1     0.17  -0.16  -0.00     0.43  -0.42  -0.00     0.00   0.01  -0.00
+    16   1     0.15   0.11  -0.00     0.50   0.33  -0.01     0.00  -0.01  -0.00
+    17   1    -0.04   0.13  -0.00     0.12  -0.13  -0.00    -0.00  -0.00   0.00
+    18   1     0.32   0.13  -0.00    -0.03  -0.05   0.00     0.00  -0.01  -0.00
+    19   8     0.02  -0.00  -0.01     0.00  -0.00  -0.00    -0.00  -0.00   0.00
+    20   1    -0.19   0.12   0.12    -0.03   0.02   0.01     0.04  -0.00  -0.01
+    21   1    -0.15  -0.14   0.02    -0.00  -0.01   0.01     0.04   0.00  -0.00
+                     49                     50                     51
+                      A                      A                      A
+ Frequencies --   3183.0883              3216.9101              3222.4157
+ Red. masses --      1.0900                 1.0914                 1.0955
+ Frc consts  --      6.5068                 6.6542                 6.7026
+ IR Inten    --      6.9826                 0.5212                 0.3340
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6     0.00   0.00  -0.00     0.00  -0.00   0.00     0.00   0.00  -0.00
+     2   6     0.00  -0.00   0.00    -0.00   0.00  -0.00     0.00  -0.00   0.00
+     3   6    -0.00   0.00  -0.00     0.01   0.02  -0.00    -0.00  -0.00   0.00
+     4   6     0.03  -0.08  -0.00    -0.00   0.00   0.00     0.01  -0.02  -0.00
+     5   8    -0.00   0.00  -0.00     0.00  -0.00   0.00    -0.00   0.00  -0.00
+     6   8    -0.00   0.00   0.00    -0.00  -0.00  -0.00    -0.00   0.00   0.00
+     7   1     0.01  -0.00   0.00    -0.00   0.00  -0.00     0.00  -0.00   0.00
+     8   1     0.00   0.01  -0.00    -0.00  -0.00   0.00     0.00   0.00  -0.00
+     9   6     0.00  -0.00   0.00     0.03  -0.08   0.00    -0.00   0.00  -0.00
+    10   1    -0.00  -0.00   0.00    -0.15  -0.22   0.00     0.02   0.02  -0.00
+    11   6     0.00  -0.00  -0.00     0.00   0.00  -0.00    -0.00   0.00   0.00
+    12   1    -0.01   0.01  -0.00    -0.39   0.87  -0.00     0.01  -0.02   0.00
+    13   7     0.00  -0.00  -0.00    -0.00  -0.00   0.00     0.00  -0.00   0.00
+    14   6     0.01   0.01  -0.00    -0.00  -0.00   0.00    -0.05  -0.07   0.00
+    15   1    -0.00   0.00   0.00    -0.00   0.00   0.00     0.00  -0.00  -0.00
+    16   1     0.00  -0.00  -0.00    -0.00   0.00   0.00     0.00   0.00  -0.00
+    17   1    -0.12  -0.17   0.00     0.02   0.03  -0.00     0.56   0.80  -0.01
+    18   1    -0.37   0.90   0.00     0.00  -0.01  -0.00    -0.08   0.19   0.00
+    19   8    -0.00   0.00   0.00     0.00  -0.00   0.00    -0.00   0.00  -0.00
+    20   1     0.00   0.00   0.00    -0.00   0.00   0.00     0.00  -0.00  -0.00
+    21   1    -0.00  -0.00  -0.00    -0.00  -0.00  -0.00     0.00   0.00   0.00
+                     52                     53                     54
+                      A                      A                      A
+ Frequencies --   3245.1692              3596.8213              3735.3918
+ Red. masses --      1.0954                 1.0469                 1.1058
+ Frc consts  --      6.7966                 7.9794                 9.0907
+ IR Inten    --      2.0582               303.3381                68.6492
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.00   0.00  -0.00    -0.00   0.00   0.00     0.00  -0.00  -0.00
+     2   6    -0.00  -0.00   0.00     0.00  -0.00  -0.00     0.00   0.00  -0.00
+     3   6    -0.05  -0.07   0.00     0.00  -0.00  -0.00    -0.00   0.00   0.00
+     4   6     0.00   0.00  -0.00     0.00   0.00  -0.00     0.00  -0.00  -0.00
+     5   8    -0.00   0.00  -0.00    -0.00  -0.00   0.00    -0.00  -0.00   0.00
+     6   8     0.00   0.00  -0.00    -0.00  -0.00   0.00     0.00   0.00  -0.00
+     7   1     0.00   0.00   0.00     0.01  -0.00   0.00     0.00  -0.00  -0.00
+     8   1    -0.00  -0.00   0.00     0.01   0.01  -0.00    -0.00  -0.01   0.00
+     9   6     0.01  -0.02  -0.00    -0.00  -0.00   0.00     0.00   0.00  -0.00
+    10   1     0.56   0.78  -0.01    -0.00  -0.00   0.00    -0.00   0.00  -0.00
+    11   6     0.00   0.00  -0.00    -0.00   0.00   0.00    -0.00  -0.00   0.00
+    12   1    -0.11   0.24  -0.00     0.00  -0.00  -0.00     0.00  -0.00  -0.00
+    13   7    -0.00  -0.00   0.00     0.05  -0.01  -0.00    -0.01  -0.09   0.00
+    14   6     0.00   0.00  -0.00    -0.00   0.00   0.00    -0.00   0.00   0.00
+    15   1    -0.00  -0.00   0.00    -0.41  -0.57   0.01     0.42   0.57  -0.01
+    16   1    -0.00   0.00   0.00    -0.30   0.64   0.00    -0.30   0.63   0.00
+    17   1    -0.01  -0.02   0.00     0.00   0.00  -0.00    -0.00  -0.00   0.00
+    18   1     0.00  -0.00   0.00    -0.00   0.00  -0.00     0.00   0.00   0.00
+    19   8    -0.00  -0.00   0.00     0.00   0.00  -0.00     0.00   0.00   0.00
+    20   1    -0.00   0.00  -0.00    -0.00  -0.00  -0.00    -0.00  -0.00  -0.00
+    21   1     0.00  -0.00  -0.00    -0.00   0.00   0.00     0.00  -0.00  -0.00
+                     55                     56                     57
+                      A                      A                      A
+ Frequencies --   3754.6580              3780.4343              3901.5061
+ Red. masses --      1.0658                 1.0450                 1.0827
+ Frc consts  --      8.8526                 8.7995                 9.7097
+ IR Inten    --     91.5351                62.1679               145.3423
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.00   0.00   0.00     0.00   0.00   0.00     0.00  -0.00  -0.00
+     2   6    -0.00  -0.00   0.00    -0.00  -0.00  -0.00     0.00   0.00   0.00
+     3   6     0.00  -0.00  -0.00    -0.00   0.00  -0.00    -0.00   0.00   0.00
+     4   6     0.00   0.00   0.00    -0.00  -0.00   0.00    -0.00   0.00   0.00
+     5   8     0.00   0.00  -0.00     0.00  -0.00  -0.00    -0.00  -0.00  -0.00
+     6   8    -0.04  -0.05   0.00     0.00   0.00  -0.00    -0.00  -0.00  -0.00
+     7   1    -0.00   0.00  -0.00    -0.03   0.00   0.00     0.00  -0.00  -0.00
+     8   1     0.61   0.79  -0.05    -0.00  -0.00   0.00     0.00   0.00   0.00
+     9   6    -0.00  -0.00   0.00     0.00   0.00  -0.00     0.00   0.00  -0.00
+    10   1     0.00  -0.00  -0.00    -0.00   0.00  -0.00     0.00   0.00   0.00
+    11   6     0.00   0.00  -0.00    -0.00   0.00   0.00    -0.00   0.00   0.00
+    12   1    -0.00   0.00   0.00     0.00  -0.00   0.00     0.00   0.00   0.00
+    13   7    -0.00  -0.00   0.00     0.00  -0.00  -0.00     0.00  -0.00  -0.00
+    14   6    -0.00  -0.00   0.00     0.00  -0.00   0.00     0.00  -0.00  -0.00
+    15   1     0.01   0.01  -0.00    -0.00  -0.00   0.00    -0.00  -0.00   0.00
+    16   1     0.00  -0.00   0.00    -0.00   0.00  -0.00    -0.00   0.00   0.00
+    17   1    -0.00   0.00   0.00     0.00   0.00  -0.00    -0.00   0.00   0.00
+    18   1    -0.00  -0.01  -0.00    -0.00  -0.00  -0.00    -0.00  -0.00   0.00
+    19   8    -0.00   0.00   0.00    -0.05  -0.01   0.02    -0.00  -0.06  -0.03
+    20   1     0.00   0.00   0.00     0.41   0.59   0.10     0.41   0.55   0.07
+    21   1     0.00  -0.00  -0.00     0.32  -0.47  -0.39    -0.37   0.46   0.41
+
+ -------------------
+ - Thermochemistry -
+ -------------------
+ Temperature   298.150 Kelvin.  Pressure   1.00000 Atm.
+ Atom     1 has atomic number  6 and mass  12.00000
+ Atom     2 has atomic number  6 and mass  12.00000
+ Atom     3 has atomic number  6 and mass  12.00000
+ Atom     4 has atomic number  6 and mass  12.00000
+ Atom     5 has atomic number  8 and mass  15.99491
+ Atom     6 has atomic number  8 and mass  15.99491
+ Atom     7 has atomic number  1 and mass   1.00783
+ Atom     8 has atomic number  1 and mass   1.00783
+ Atom     9 has atomic number  6 and mass  12.00000
+ Atom    10 has atomic number  1 and mass   1.00783
+ Atom    11 has atomic number  6 and mass  12.00000
+ Atom    12 has atomic number  1 and mass   1.00783
+ Atom    13 has atomic number  7 and mass  14.00307
+ Atom    14 has atomic number  6 and mass  12.00000
+ Atom    15 has atomic number  1 and mass   1.00783
+ Atom    16 has atomic number  1 and mass   1.00783
+ Atom    17 has atomic number  1 and mass   1.00783
+ Atom    18 has atomic number  1 and mass   1.00783
+ Atom    19 has atomic number  8 and mass  15.99491
+ Atom    20 has atomic number  1 and mass   1.00783
+ Atom    21 has atomic number  1 and mass   1.00783
+ Molecular mass:   156.06607 amu.
+ Principal axes and moments of inertia in atomic units:
+                           1         2         3
+     Eigenvalues --   521.320673949.009134466.50605
+           X            1.00000   0.00266  -0.00145
+           Y           -0.00266   1.00000   0.00083
+           Z            0.00145  -0.00082   1.00000
+ This molecule is an asymmetric top.
+ Rotational symmetry number  1.
+ Warning -- assumption of classical behavior for rotation
+           may cause significant error
+ Rotational temperatures (Kelvin)      0.16614     0.02193     0.01939
+ Rotational constants (GHZ):           3.46186     0.45701     0.40406
+ Zero-point vibrational energy     440717.3 (Joules/Mol)
+                                  105.33396 (Kcal/Mol)
+ Warning -- explicit consideration of  19 degrees of freedom as
+           vibrations may cause significant error
+ Vibrational temperatures:     61.54    73.08    82.29   104.38   161.60
+          (Kelvin)            261.43   373.18   379.98   407.14   440.17
+                              535.87   558.04   564.37   616.31   696.76
+                              707.84   740.06   771.89   877.13   906.97
+                              963.27  1090.23  1098.20  1146.85  1208.55
+                             1225.80  1307.23  1365.11  1438.57  1485.20
+                             1499.86  1632.51  1665.61  1736.13  1766.04
+                             1915.59  1973.85  2002.88  2041.88  2207.24
+                             2223.77  2236.40  2311.42  2346.90  2377.44
+                             2383.36  2433.17  4091.43  4579.75  4628.42
+                             4636.34  4669.07  5175.02  5374.40  5402.12
+                             5439.20  5613.40
+ 
+ Zero-point correction=                           0.167860 (Hartree/Particle)
+ Thermal correction to Energy=                    0.180363
+ Thermal correction to Enthalpy=                  0.181308
+ Thermal correction to Gibbs Free Energy=         0.128340
+ Sum of electronic and zero-point Energies=           -551.390155
+ Sum of electronic and thermal Energies=              -551.377652
+ Sum of electronic and thermal Enthalpies=            -551.376708
+ Sum of electronic and thermal Free Energies=         -551.429676
+ 
+                     E (Thermal)             CV                S
+                      KCal/Mol        Cal/Mol-Kelvin    Cal/Mol-Kelvin
+ Total                  113.180             45.220            111.480
+ Electronic               0.000              0.000              0.000
+ Translational            0.889              2.981             41.045
+ Rotational               0.889              2.981             30.598
+ Vibrational            111.402             39.258             39.837
+ Vibration     1          0.595              1.980              5.127
+ Vibration     2          0.595              1.977              4.786
+ Vibration     3          0.596              1.975              4.552
+ Vibration     4          0.599              1.967              4.083
+ Vibration     5          0.607              1.939              3.228
+ Vibration     6          0.630              1.865              2.311
+ Vibration     7          0.668              1.747              1.666
+ Vibration     8          0.671              1.739              1.635
+ Vibration     9          0.682              1.705              1.516
+ Vibration    10          0.696              1.662              1.384
+ Vibration    11          0.744              1.529              1.070
+ Vibration    12          0.756              1.496              1.008
+ Vibration    13          0.760              1.487              0.992
+ Vibration    14          0.790              1.409              0.864
+ Vibration    15          0.840              1.285              0.699
+ Vibration    16          0.848              1.268              0.678
+ Vibration    17          0.869              1.218              0.623
+ Vibration    18          0.891              1.169              0.573
+ Vibration    19          0.969              1.011              0.433
+                       Q            Log10(Q)             Ln(Q)
+ Total Bot       0.928296D-59        -59.032314       -135.926926
+ Total V=0       0.150668D+19         18.178020         41.856438
+ Vib (Bot)       0.111595D-72        -72.952356       -167.979008
+ Vib (Bot)    1  0.483658D+01          0.684539          1.576208
+ Vib (Bot)    2  0.406975D+01          0.609567          1.403581
+ Vib (Bot)    3  0.361183D+01          0.557728          1.284216
+ Vib (Bot)    4  0.284173D+01          0.453582          1.044412
+ Vib (Bot)    5  0.182260D+01          0.260690          0.600262
+ Vib (Bot)    6  0.110474D+01          0.043260          0.099609
+ Vib (Bot)    7  0.749085D+00         -0.125469         -0.288902
+ Vib (Bot)    8  0.733959D+00         -0.134328         -0.309303
+ Vib (Bot)    9  0.678362D+00         -0.168539         -0.388075
+ Vib (Bot)   10  0.619529D+00         -0.207939         -0.478796
+ Vib (Bot)   11  0.487996D+00         -0.311584         -0.717449
+ Vib (Bot)   12  0.463585D+00         -0.333871         -0.768765
+ Vib (Bot)   13  0.456945D+00         -0.340136         -0.783193
+ Vib (Bot)   14  0.407284D+00         -0.390103         -0.898245
+ Vib (Bot)   15  0.344090D+00         -0.463328         -1.066853
+ Vib (Bot)   16  0.336438D+00         -0.473095         -1.089341
+ Vib (Bot)   17  0.315428D+00         -0.501100         -1.153825
+ Vib (Bot)   18  0.296298D+00         -0.528272         -1.216391
+ Vib (Bot)   19  0.242503D+00         -0.615283         -1.416741
+ Vib (V=0)       0.181124D+05          4.257977          9.804355
+ Vib (V=0)    1  0.536236D+01          0.729356          1.679404
+ Vib (V=0)    2  0.460035D+01          0.662791          1.526132
+ Vib (V=0)    3  0.414628D+01          0.617658          1.422211
+ Vib (V=0)    4  0.338538D+01          0.529607          1.219466
+ Vib (V=0)    5  0.238994D+01          0.378386          0.871266
+ Vib (V=0)    6  0.171262D+01          0.233661          0.538025
+ Vib (V=0)    7  0.140063D+01          0.146322          0.336920
+ Vib (V=0)    8  0.138809D+01          0.142416          0.327925
+ Vib (V=0)    9  0.134272D+01          0.127985          0.294696
+ Vib (V=0)   10  0.129613D+01          0.112647          0.259379
+ Vib (V=0)   11  0.119867D+01          0.078700          0.181213
+ Vib (V=0)   12  0.118184D+01          0.072560          0.167076
+ Vib (V=0)   13  0.117735D+01          0.070904          0.163263
+ Vib (V=0)   14  0.114489D+01          0.058763          0.135307
+ Vib (V=0)   15  0.110696D+01          0.044131          0.101616
+ Vib (V=0)   16  0.110265D+01          0.042439          0.097719
+ Vib (V=0)   17  0.109118D+01          0.037897          0.087260
+ Vib (V=0)   18  0.108120D+01          0.033906          0.078071
+ Vib (V=0)   19  0.105570D+01          0.023542          0.054209
+ Electronic      0.100000D+01          0.000000          0.000000
+ Translational   0.766331D+08          7.884417         18.154540
+ Rotational      0.108549D+07          6.035626         13.897543
+ 
+                                                              Oproto sp
+                                                             IR Spectrum
+ 
+     3   333   3          3333          2                                   11111111  1111  11 11 111                                
+     9   777   5          2221          8                                   66666555  4333  22 11 000 9988777 666554443333222 11     
+     0   853   9          4218          4                                   95530543  1973  20 53 430 4054965 731319829870865 817554 
+     2   055   7          5273          4                                   17217464  9221  77 85 220 9920738 000642482826349 223713 
+ 
+     X   XXX   X          XXXX          X                                   XXXXXXXX  XXXX  XX XX XXX XXXXXXX XXXXXXXXXXXXXXX XXXXXX 
+                                        X                                    X         XX                                            
+                                        X                                    X         X                                             
+                                        X                                    X         X                                             
+                                        X                                    X                                                       
+                                        X                                    X                                                       
+                                        X                                    X                                                       
+                                        X                                                                                            
+                                        X                                                                                            
+                                        X                                                                                            
+                                        X                                                                                            
+                                        X                                                                                            
+                                        X                                                                                            
+                                        X                                                                                            
+                                        X                                                                                            
+                                        X                                                                                            
+                                        X                                                                                            
+                                        X                                                                                            
+                                        X                                                                                            
+                                        X                                                                                            
+ 
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6          -0.000034000    0.000046938    0.000013484
+      2        6           0.000069915    0.000151863    0.000031874
+      3        6           0.000354542   -0.000060580   -0.000007472
+      4        6           0.000108076    0.000127798   -0.000012227
+      5        8           0.000012741    0.000033999   -0.000046730
+      6        8           0.000165807   -0.000106803   -0.000033747
+      7        1          -0.000074914   -0.000058102    0.000050656
+      8        1          -0.000004885    0.000048515    0.000006147
+      9        6          -0.000281152   -0.000002594   -0.000001823
+     10        1          -0.000073847   -0.000175166    0.000001252
+     11        6           0.000012109   -0.000311145    0.000018767
+     12        1          -0.000074514    0.000088940   -0.000000418
+     13        7           0.000128249   -0.000005385   -0.000021430
+     14        6          -0.000290069    0.000291129   -0.000001814
+     15        1           0.000025997   -0.000009370    0.000003758
+     16        1           0.000003762    0.000039254    0.000006091
+     17        1          -0.000048467   -0.000012894    0.000002281
+     18        1          -0.000004505   -0.000063467    0.000003303
+     19        8           0.000019810   -0.000054518   -0.000010626
+     20        1          -0.000033179   -0.000016966   -0.000026287
+     21        1           0.000018524    0.000048553    0.000024960
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000354542 RMS     0.000103681
+ Z-matrix is all fixed cartesians, so copy forces.
+ Leave Link  716 at Mon Oct 16 01:27:05 2023, MaxMem=174483046400 cpu:               3.1 elap:               0.1
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of    2
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- analytic derivatives used.
+ ITU=  0
+     Eigenvalues ---    0.00008   0.00045   0.00055   0.00087   0.00238
+     Eigenvalues ---    0.00560   0.00762   0.00813   0.00893   0.01320
+     Eigenvalues ---    0.01407   0.01419   0.01700   0.02020   0.02686
+     Eigenvalues ---    0.02728   0.03107   0.04324   0.05219   0.05513
+     Eigenvalues ---    0.05652   0.05950   0.06958   0.07708   0.08158
+     Eigenvalues ---    0.08701   0.09596   0.10564   0.13228   0.16166
+     Eigenvalues ---    0.17257   0.17285   0.18293   0.19730   0.23066
+     Eigenvalues ---    0.24774   0.28098   0.28300   0.38774   0.43793
+     Eigenvalues ---    0.53125   0.64058   0.67728   0.77589   0.88219
+     Eigenvalues ---    0.90323   0.98546   1.00591   1.03453   1.09315
+     Eigenvalues ---    1.14277   1.17612   1.17939   1.25178   1.28045
+     Eigenvalues ---    1.30353   1.33603
+ Angle between quadratic step and forces=  79.76 degrees.
+ Linear search not attempted -- first point.
+ B after Tr=     0.000071   -0.000211   -0.000199
+         Rot=    1.000000    0.000017   -0.000005   -0.000014 Ang=   0.00 deg.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    X1       -0.00103  -0.00003   0.00000   0.00010   0.00016  -0.00087
+    Y1        0.25153   0.00005   0.00000  -0.00128  -0.00149   0.25004
+    Z1        0.01229   0.00001   0.00000  -0.00038  -0.00058   0.01171
+    X2       -2.69971   0.00007   0.00000   0.00044   0.00050  -2.69921
+    Y2        0.45914   0.00015   0.00000  -0.00066  -0.00094   0.45819
+    Z2        0.01438   0.00003   0.00000  -0.00118  -0.00137   0.01301
+    X3        1.11525   0.00035   0.00000   0.00047   0.00060   1.11585
+    Y3       -2.19507  -0.00006   0.00000  -0.00135  -0.00153  -2.19660
+    Z3        0.03690  -0.00001   0.00000  -0.00057  -0.00070   0.03619
+    X4        1.58809   0.00011   0.00000  -0.00086  -0.00086   1.58723
+    Y4        2.41781   0.00013   0.00000  -0.00056  -0.00073   2.41707
+    Z4       -0.01422  -0.00001   0.00000   0.00014  -0.00016  -0.01438
+    X5       -4.09279   0.00001   0.00000   0.00013   0.00024  -4.09255
+    Y5       -1.54142   0.00003   0.00000  -0.00052  -0.00084  -1.54226
+    Z5        0.08637  -0.00005   0.00000  -0.00170  -0.00181   0.08456
+    X6       -3.95735   0.00017   0.00000   0.00150   0.00150  -3.95585
+    Y6        2.62529  -0.00011   0.00000  -0.00042  -0.00074   2.62454
+    Z6       -0.04512  -0.00003   0.00000  -0.00213  -0.00238  -0.04750
+    X7       -5.97742  -0.00007   0.00000  -0.00034  -0.00024  -5.97765
+    Y7       -1.13485  -0.00006   0.00000  -0.00189  -0.00226  -1.13711
+    Z7        0.01617   0.00005   0.00000   0.00008  -0.00003   0.01614
+    X8       -2.80432  -0.00000   0.00000   0.00154   0.00150  -2.80282
+    Y8        4.05345   0.00005   0.00000  -0.00034  -0.00064   4.05281
+    Z8       -0.13587   0.00001   0.00000  -0.00088  -0.00119  -0.13706
+    X9        3.72430  -0.00028   0.00000   0.00003   0.00017   3.72446
+    Y9       -2.46118  -0.00000   0.00000  -0.00016  -0.00027  -2.46145
+    Z9        0.03034  -0.00000   0.00000  -0.00024  -0.00039   0.02995
+   X10       -0.09085  -0.00007   0.00000   0.00103   0.00120  -0.08965
+   Y10       -3.86913  -0.00018   0.00000  -0.00236  -0.00257  -3.87170
+   Z10        0.05788   0.00000   0.00000  -0.00105  -0.00112   0.05676
+   X11        5.32530   0.00001   0.00000  -0.00026  -0.00018   5.32512
+   Y11       -0.29354  -0.00031   0.00000   0.00006  -0.00000  -0.29354
+   Z11        0.00087   0.00002   0.00000   0.00038   0.00014   0.00101
+   X12        4.56692  -0.00007   0.00000   0.00014   0.00033   4.56725
+   Y12       -4.34879   0.00009   0.00000   0.00020   0.00012  -4.34867
+   Z12        0.04706  -0.00000   0.00000  -0.00052  -0.00061   0.04645
+   X13        7.87429   0.00013   0.00000   0.00008   0.00016   7.87446
+   Y13       -0.55470  -0.00001   0.00000   0.00121   0.00121  -0.55349
+   Z13       -0.00524  -0.00002   0.00000  -0.00021  -0.00047  -0.00571
+   X14        4.20028  -0.00029   0.00000  -0.00121  -0.00120   4.19909
+   Y14        2.15408   0.00029   0.00000   0.00047   0.00037   2.15445
+   Z14       -0.01977  -0.00000   0.00000   0.00068   0.00036  -0.01941
+   X15        9.02848   0.00003   0.00000  -0.00044  -0.00039   9.02809
+   Y15        0.96993  -0.00001   0.00000   0.00166   0.00169   0.97162
+   Z15       -0.03010   0.00000   0.00000   0.00238   0.00206  -0.02804
+   X16        8.69141   0.00000   0.00000   0.00100   0.00113   8.69254
+   Y16       -2.28396   0.00004   0.00000   0.00173   0.00175  -2.28221
+   Z16        0.00713   0.00001   0.00000   0.00202   0.00182   0.00895
+   X17        5.40556  -0.00005   0.00000  -0.00194  -0.00198   5.40358
+   Y17        3.83274  -0.00001   0.00000   0.00087   0.00080   3.83354
+   Z17       -0.03778   0.00000   0.00000   0.00126   0.00088  -0.03690
+   X18        0.82779  -0.00000   0.00000  -0.00194  -0.00199   0.82580
+   Y18        4.34407  -0.00006   0.00000  -0.00119  -0.00137   4.34270
+   Z18       -0.02185   0.00000   0.00000   0.00049   0.00014  -0.02171
+   X19       -8.87044   0.00002   0.00000   0.00015   0.00024  -8.87020
+   Y19       -0.76190  -0.00005   0.00000   0.00025  -0.00021  -0.76211
+   Z19       -0.27995  -0.00001   0.00000   0.00264   0.00256  -0.27739
+   X20       -9.96469  -0.00003   0.00000  -0.00548  -0.00535  -9.97004
+   Y20       -2.21506  -0.00002   0.00000   0.00472   0.00422  -2.21084
+   Z20       -0.47166  -0.00003   0.00000   0.00068   0.00066  -0.47101
+   X21       -9.79891   0.00002   0.00000   0.00436   0.00443  -9.79448
+   Y21        0.42341   0.00005   0.00000   0.00390   0.00345   0.42686
+   Z21        0.75743   0.00002   0.00000   0.00232   0.00220   0.75964
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000355     0.000450     YES
+ RMS     Force            0.000104     0.000300     YES
+ Maximum Displacement     0.005348     0.001800     NO 
+ RMS     Displacement     0.001600     0.001200     NO 
+ Predicted change in Energy=-9.371505D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Oct 16 01:27:05 2023, MaxMem=174483046400 cpu:               0.5 elap:               0.0
+ (Enter /ihome/crc/install/gaussian/c01/avx2/tar/g16/l9999.exe)
+
+ ----------------------------------------------------------------------
+
+ Electric dipole moment (input orientation):
+ (Debye = 10**-18 statcoulomb cm , SI units = C m)
+                  (au)            (Debye)         (10**-30 SI)
+   Tot        0.663709D+00      0.168698D+01      0.562716D+01
+   x         -0.523066D+00     -0.132950D+01     -0.443474D+01
+   y          0.344185D+00      0.874832D+00      0.291812D+01
+   z          0.220111D+00      0.559466D+00      0.186618D+01
+
+ Dipole polarizability, Alpha (input orientation).
+ (esu units = cm**3 , SI units = C**2 m**2 J**-1)
+ Alpha(0;0):
+               (au)            (10**-24 esu)      (10**-40 SI)
+   iso        0.125874D+03      0.186526D+02      0.207538D+02
+   aniso      0.131171D+03      0.194375D+02      0.216271D+02
+   xx         0.209278D+03      0.310119D+02      0.345053D+02
+   yx        -0.584965D+01     -0.866828D+00     -0.964477D+00
+   yy         0.106164D+03      0.157319D+02      0.175041D+02
+   zx        -0.277975D+00     -0.411916D-01     -0.458318D-01
+   zy        -0.280173D+00     -0.415174D-01     -0.461943D-01
+   zz         0.621793D+02      0.921402D+01      0.102520D+02
+
+ ----------------------------------------------------------------------
+
+ Dipole orientation:
+     6          0.08633151          0.19404199          0.13532855
+     6         -1.28828553         -0.46960396          2.37049891
+     6         -0.04952356         -1.42863459         -2.00500010
+     6          1.57821525          2.42429984         -0.00245672
+     8         -2.58886297         -2.53102780          2.45479710
+     8         -1.34142726          0.90397076          4.46521727
+     1         -3.52502421         -2.74855724          4.12762431
+     1         -0.35939767          2.44464971          4.26703828
+     6          1.25579454         -0.83687005         -4.20134955
+     1         -1.19032184         -3.14565901         -1.91565004
+     6          2.75210740          1.39966142         -4.34877245
+     1          1.13926341         -2.09333714         -5.83874127
+     7          4.02724689          1.97671379         -6.49508500
+     6          2.88673274          3.01841205         -2.19971938
+     1          5.09143796          3.56056294         -6.62229646
+     1          3.94227408          0.84103916         -8.03170379
+     1          4.03085495          4.73731760         -2.28504201
+     1          1.75770557          3.73217208          1.59311861
+     8         -5.18760768         -3.18525774          6.50280388
+     1         -6.36856269         -4.58136841          6.54802017
+     1         -4.50169546         -3.06223564          8.19323302
+
+ Electric dipole moment (dipole orientation):
+ (Debye = 10**-18 statcoulomb cm , SI units = C m)
+                  (au)            (Debye)         (10**-30 SI)
+   Tot        0.663709D+00      0.168698D+01      0.562716D+01
+   x          0.000000D+00      0.000000D+00      0.000000D+00
+   y          0.000000D+00      0.000000D+00      0.000000D+00
+   z          0.663709D+00      0.168698D+01      0.562716D+01
+
+ Dipole polarizability, Alpha (dipole orientation).
+ (esu units = cm**3 , SI units = C**2 m**2 J**-1)
+ Alpha(0;0):
+               (au)            (10**-24 esu)      (10**-40 SI)
+   iso        0.125874D+03      0.186526D+02      0.207538D+02
+   aniso      0.131171D+03      0.194375D+02      0.216271D+02
+   xx         0.105918D+03      0.156955D+02      0.174636D+02
+   yx         0.316984D+02      0.469722D+01      0.522636D+01
+   yy         0.101503D+03      0.150412D+02      0.167356D+02
+   zx        -0.550806D+02     -0.816210D+01     -0.908156D+01
+   zy        -0.147685D+02     -0.218846D+01     -0.243499D+01
+   zz         0.170200D+03      0.252211D+02      0.280623D+02
+
+ ----------------------------------------------------------------------
+ Unable to Open any file for archive entry.
+ 1\1\GINC-SMP-2048-N0\Freq\RMP2-FC\Aug-CC-pVDZ\C7H10N1O3(1+)\NAM340\16-
+ Oct-2023\0\\#P freq mp2/aug-cc-pvdz Symmetry=Follow\\Oproto sp\\1,1\C,
+ -0.0005469105,0.1331036828,0.0065043677\C,-1.4286273703,0.2429652703,0
+ .0076107065\C,0.5901632072,-1.1615816991,0.0195246015\C,0.8403786808,1
+ .2794473249,-0.0075254537\O,-2.1658089543,-0.8156862647,0.0457051203\O
+ ,-2.0941377929,1.3892414152,-0.0238749734\H,-3.1631126419,-0.600534439
+ 5,0.0085541588\H,-1.4839821952,2.1449911745,-0.0718999336\C,1.97081221
+ 75,-1.3024010262,0.0160562802\H,-0.0480763799,-2.0474540857,0.03063014
+ 56\C,2.8180266002,-0.1553334019,0.0004606196\H,2.4167084022,-2.3012781
+ 913,0.0249032174\N,4.1668974618,-0.2935359584,-0.0027749055\C,2.222693
+ 2018,1.1398884486,-0.0104640148\H,4.7776671169,0.5132635998,-0.0159274
+ 081\H,4.5992956877,-1.2086218278,0.003770479\H,2.8604972457,2.02820029
+ 31,-0.0199927648\H,0.4380475715,2.2987832467,-0.011560952\O,-4.6940358
+ 013,-0.4031782627,-0.1481409095\H,-5.2730895074,-1.1721584604,-0.24959
+ 27413\H,-5.1853598396,0.2240601618,0.4008153605\\Version=ES64L-G16RevC
+ .01\State=1-A\HF=-549.8374993\MP2=-551.5580157\RMSD=3.497e-09\RMSF=1.0
+ 37e-04\ZeroPoint=0.1678604\Thermal=0.1803635\ETot=-551.3776522\HTot=-5
+ 51.3767081\GTot=-551.4296756\Dipole=-0.5230658,0.3441853,0.220111\Dipo
+ leDeriv=-2.3535381,0.1740691,0.0040612,0.2114531,-0.2432082,0.0023165,
+ -0.000804,0.0015072,-0.063961,4.0902126,-0.1942919,-0.007315,0.2930646
+ ,1.4966059,-0.035378,-0.0327432,-0.0381041,0.3246378,0.821103,-0.09830
+ 36,-0.0014535,-0.5563979,0.1269333,-0.0007267,0.0100599,-0.0020258,-0.
+ 0600869,0.9293753,-0.0003065,-0.0041928,0.3581585,0.062634,-0.0013151,
+ -0.0158226,0.0010778,-0.0810063,-2.5120248,-0.4245541,0.0007577,-1.173
+ 3222,-0.6347319,0.0157623,0.042057,0.0159483,-0.2372371,-1.0207848,0.3
+ 976712,-0.0093439,0.9455284,-1.0754759,0.0210663,-0.0075925,0.0198303,
+ -0.2465509,2.0600646,0.1637925,0.025283,-0.1271484,0.2086551,-0.004989
+ 4,0.0610403,-0.0002584,0.2729997,0.2340549,-0.0762752,0.0059988,-0.186
+ 4704,0.4149959,-0.0053674,0.0097696,-0.0050568,0.3126259,-0.8651752,0.
+ 0134112,0.0017227,-0.6976832,0.101499,0.0000423,0.0108246,-0.0022287,-
+ 0.096127,0.0843567,-0.0316896,0.0002861,-0.0236316,0.0609975,0.0004906
+ ,-0.0001119,0.0007396,0.1319682,2.5595799,-0.2277919,-0.0052176,-0.315
+ 1658,0.1350219,0.0007592,-0.0055687,0.0007068,0.1142191,0.0274696,0.04
+ 05657,-0.0001449,0.0269456,0.0251167,0.0010726,-0.0006924,0.000893,0.1
+ 357335,-2.3074951,0.1972851,0.002927,0.2348339,-0.168872,-0.0037984,-0
+ .0007968,-0.0032297,-0.4422313,-0.7280791,0.0937257,0.001243,0.9128567
+ ,-0.0647347,-0.002858,-0.0072168,0.0001731,-0.0997232,0.3050965,0.0598
+ 369,-0.0004497,0.2076318,0.1522677,0.0011423,-0.0003471,0.0014946,0.30
+ 35546,0.2439596,-0.0779514,0.0012863,-0.2301967,0.2083911,0.0016044,0.
+ 0042269,0.0009635,0.3033917,0.0168719,-0.0361968,0.0006554,-0.0206815,
+ 0.0344735,0.0010374,0.0017568,0.0005377,0.1377813,0.0396521,0.0817655,
+ -0.001123,0.0725868,-0.0222623,0.0019931,0.0000317,0.0009762,0.1311224
+ ,-1.1702103,-0.0287973,-0.0712733,0.0544297,-0.4499054,0.0143608,-0.12
+ 88168,0.0120942,-0.4933985,0.2630975,0.0093447,0.0381334,0.060938,0.31
+ 95227,0.007719,0.0618739,0.0053884,0.340115,0.2824132,-0.0353094,0.018
+ 1592,-0.0477294,0.3120761,-0.0149338,-0.001128,-0.0114274,0.3121731\Po
+ lar=209.2783484,-5.8496483,106.1642821,-0.2779746,-0.2801733,62.179295
+ 8\PG=C01 [X(C7H10N1O3)]\NImag=0\\0.71348979,0.01102811,0.70655667,-0.0
+ 0152983,-0.00683905,0.12767660,-0.28231642,0.01318067,0.00026565,0.776
+ 73545,0.01754976,-0.11115617,0.00059005,0.05782222,0.77414300,-0.00030
+ 912,0.00035622,-0.07123096,-0.00363656,-0.01752757,0.20491277,-0.12528
+ 092,0.06126659,-0.00050165,-0.03852011,0.03431259,-0.00025355,0.752787
+ 93,0.08671227,-0.29214961,0.00254799,0.02753218,0.00613499,-0.00035456
+ ,0.03102129,0.69580170,-0.00068743,0.00221859,-0.05312893,-0.00051891,
+ -0.00018952,-0.00598519,-0.00202317,-0.00624179,0.12276839,-0.16489071
+ ,-0.09194304,0.00133013,-0.04693955,-0.02432137,0.00049250,0.02146895,
+ -0.01425056,0.00003345,0.72393602,-0.11468905,-0.26058318,0.00243281,-
+ 0.01708010,0.01469808,-0.00022927,-0.00012868,-0.04864115,0.00079684,-
+ 0.02327524,0.70730463,0.00134844,0.00210643,-0.05004366,0.00037665,-0.
+ 00019237,-0.00733024,-0.00004005,0.00061862,0.00183137,-0.00212046,-0.
+ 00431216,0.11832542,-0.05450857,-0.04460388,0.00163244,-0.23548505,-0.
+ 17380341,0.00532305,0.00500720,-0.00895626,0.00018096,0.00405170,0.012
+ 08543,-0.00004251,0.59879792,-0.02809038,0.00336866,0.00010220,-0.1272
+ 8789,-0.33242865,0.00985763,0.00824881,-0.00867163,0.00020311,0.007891
+ 76,0.00379300,-0.00009353,0.10978111,0.48137070,0.00139424,0.00005289,
+ 0.00984593,0.00289244,0.00890626,-0.06544928,-0.00027269,0.00028636,-0
+ .00015568,-0.00056841,-0.00026073,0.00411801,0.00737226,-0.01747162,0.
+ 05132118,-0.02294205,0.04315964,-0.00097618,-0.19744731,0.08987721,-0.
+ 00091658,-0.00195257,-0.00806781,0.00005399,0.00433671,0.00312602,-0.0
+ 0009217,0.02333736,-0.03127351,0.00056969,0.43613191,0.02965226,-0.011
+ 44462,0.00048876,0.11637707,-0.29214435,0.00658778,-0.00621049,0.00760
+ 495,0.00008441,-0.01158581,-0.01078428,0.00012311,0.00554181,-0.085657
+ 98,0.00326837,0.09237417,0.68712515,-0.00023080,0.00065359,0.01621393,
+ -0.00293189,0.00822655,-0.05734790,-0.00000590,0.00003502,0.00725593,0
+ .00012840,0.00009199,-0.00105847,-0.00029100,0.00378510,0.01373076,-0.
+ 01243317,-0.02975338,0.03817521,0.01381542,0.00283007,-0.00048216,-0.0
+ 4149294,-0.03810915,0.00131976,-0.00260570,0.00299648,0.00007524,-0.00
+ 339771,-0.00323101,0.00004561,-0.26657271,0.06577485,-0.00919095,-0.00
+ 025405,0.01533216,-0.00044827,0.27806812,-0.00259394,-0.00538114,0.000
+ 51938,-0.04508980,0.01010001,-0.00162726,0.00101451,-0.00093469,-0.000
+ 06226,-0.00044989,0.00115021,0.00017344,0.09262412,-0.07290788,0.00412
+ 626,0.00131414,-0.00193713,-0.00015023,-0.04310807,0.08619282,0.000223
+ 29,0.00082008,0.00539851,0.00192294,-0.00197936,-0.00187918,-0.0000754
+ 1,0.00004384,-0.00060809,0.00020600,0.00001739,0.00220874,-0.01082313,
+ 0.00349465,-0.02736995,-0.00010077,0.00061641,-0.00345762,0.00873626,0
+ .00000544,0.03903233,-0.00553826,0.00170104,-0.00003976,0.02281134,0.0
+ 1633946,-0.00127573,0.00086915,-0.00166016,0.00001124,0.00138765,0.007
+ 73254,0.00000039,-0.00066893,0.00765109,-0.00010205,-0.23372728,-0.245
+ 02807,0.01643027,-0.00044563,0.00048703,-0.00002764,0.21990481,-0.0026
+ 9996,0.00171173,-0.00016413,-0.02541615,-0.04012981,0.00201924,0.00001
+ 997,-0.00147152,-0.00006350,0.00111566,0.00310673,-0.00001905,0.004217
+ 55,-0.00242996,0.00031824,-0.19457185,-0.29906860,0.01734779,0.0004440
+ 2,-0.00021281,-0.00002214,0.21950030,0.33751976,-0.00002657,-0.0002074
+ 9,-0.00185121,0.00086890,0.00058238,-0.00528802,0.00007689,-0.00004169
+ ,-0.00077829,0.00000126,0.00021966,-0.00062786,-0.00016435,0.00009325,
+ 0.00908786,0.01406207,0.01909560,-0.01177116,0.00011519,0.00002716,-0.
+ 00106409,-0.01482932,-0.01950922,0.01028275,-0.03108080,0.04165107,-0.
+ 00035725,0.01881889,0.00419404,-0.00009800,-0.41117726,0.01407363,0.00
+ 101514,-0.01826753,-0.01667187,0.00020541,-0.00501020,-0.00550923,0.00
+ 021705,-0.00445862,0.00577842,-0.00003014,0.00274903,-0.00013427,0.000
+ 02739,-0.00103591,-0.00108866,-0.00000130,0.75825634,0.02568427,0.0097
+ 6089,-0.00035334,0.01091659,-0.00791081,0.00014378,0.04898132,-0.11656
+ 075,0.00069745,-0.00428073,-0.00848085,0.00023417,-0.00458715,-0.00228
+ 483,0.00013060,-0.00002771,0.00412411,-0.00003282,0.00239890,0.0000143
+ 2,0.00002275,-0.00083412,-0.00032963,-0.00002104,-0.04049166,0.7030042
+ 8,-0.00007075,0.00007113,0.00214889,-0.00018145,0.00008807,0.00613704,
+ 0.00067069,0.00058108,-0.04362911,0.00010640,-0.00002818,0.00279037,0.
+ 00006948,0.00004999,-0.00032572,0.00005181,-0.00010611,-0.00132657,-0.
+ 00013771,-0.00001824,0.00013420,0.00001017,0.00003321,0.00029161,-0.00
+ 186819,-0.00620879,0.11042377,0.01005196,0.01205637,-0.00014228,0.0015
+ 6643,0.00097872,-0.00001964,-0.15473057,-0.14205506,0.00175976,-0.0009
+ 0097,0.00368955,-0.00003315,-0.00321625,0.00066144,0.00004773,-0.00000
+ 322,-0.00062146,0.00001375,-0.00055853,0.00007761,-0.00004237,0.000228
+ 35,-0.00000217,-0.00000678,-0.01166387,-0.02406578,0.00030683,0.163959
+ 17,-0.01677727,-0.01617551,0.00019127,-0.00254291,-0.00213528,0.000050
+ 82,-0.14166612,-0.25285562,0.00273899,0.00383588,-0.00322453,0.0000926
+ 4,-0.00001840,0.00145987,-0.00004801,0.00014727,0.00073313,-0.00001696
+ ,0.00071327,0.00053964,0.00004981,-0.00022759,-0.00003522,-0.00001147,
+ 0.00655697,0.00682091,-0.00006926,0.14823284,0.26322356,0.00012977,0.0
+ 0017979,0.00113219,0.00006663,0.00002570,-0.00241308,0.00167838,0.0027
+ 0403,-0.03469147,-0.00004333,0.00006520,0.00474275,0.00005978,-0.00005
+ 402,0.00040365,-0.00001408,0.00002252,0.00016013,0.00005118,0.00000232
+ ,-0.00025313,-0.00000243,-0.00000888,-0.00006328,0.00005026,0.00003148
+ ,0.00302618,-0.00194377,-0.00295447,0.02424555,0.02075911,-0.00704247,
+ 0.00006592,-0.02821621,-0.00036195,0.00018945,-0.03811034,-0.02286151,
+ 0.00028230,-0.02206772,0.03446274,-0.00018619,0.01180686,0.00833830,-0
+ .00037389,0.00614534,-0.00953998,0.00005634,-0.00614407,0.00069956,-0.
+ 00008065,0.00137286,0.00186523,0.00000189,-0.16718057,-0.10984564,0.00
+ 162837,-0.00529587,0.00233141,0.00001722,0.77782993,-0.00787362,-0.040
+ 94736,0.00059800,0.00408365,-0.00510004,-0.00010541,-0.03630951,0.0353
+ 8174,-0.00048760,0.04953006,0.01887316,-0.00052869,-0.00518134,-0.0018
+ 9577,0.00024145,0.00140701,0.00026978,0.00001562,0.00173686,-0.0004347
+ 2,-0.00001715,0.00046423,0.00024261,0.00004607,-0.07434065,-0.26162351
+ ,0.00259002,0.00147676,0.00069032,0.00007205,-0.00828635,0.70098538,-0
+ .00007748,0.00024907,-0.00450701,0.00004545,0.00002777,-0.00049870,0.0
+ 0055864,-0.00028331,-0.00585437,-0.00039108,-0.00015529,-0.00568498,-0
+ .00005512,0.00001022,-0.00019019,-0.00000542,0.00004632,0.00031516,0.0
+ 0007425,0.00001640,0.00024045,-0.00003293,-0.00002116,0.00011294,0.001
+ 20227,0.00266064,-0.05864990,0.00004856,0.00009448,0.00986789,-0.00234
+ 256,-0.00571015,0.15430165,-0.00547493,-0.00039275,0.00007798,0.000558
+ 13,0.00183027,-0.00003179,-0.00776513,0.02823256,-0.00026943,-0.000707
+ 47,-0.00070028,0.00000145,-0.00025757,-0.00016281,-0.00000630,-0.00086
+ 426,0.00023224,-0.00001097,0.00021938,-0.00000671,0.00001022,-0.000009
+ 69,-0.00018583,0.00001104,-0.10315024,0.10801101,-0.00086573,0.0009845
+ 3,0.00003775,-0.00001523,0.00895025,-0.01874065,0.00017104,0.10759020,
+ -0.00062385,0.00208705,0.00007373,-0.00001132,0.00019413,0.00001645,-0
+ .00322899,0.00154237,-0.00000609,-0.00112055,0.00013492,-0.00000828,0.
+ 00007561,-0.00000854,0.00000582,-0.00016005,0.00013060,-0.00001320,-0.
+ 00001927,0.00000848,-0.00000231,-0.00002200,-0.00001259,-0.00000093,0.
+ 10826999,-0.30146545,0.00242414,-0.00007165,0.00081211,-0.00005417,0.0
+ 1407201,-0.01588018,0.00014579,-0.11383079,0.31376750,0.00002211,0.000
+ 04784,0.00870461,0.00002818,0.00000567,0.00141898,0.00006289,-0.000118
+ 96,0.00096441,0.00003698,0.00000399,-0.00111875,-0.00000149,-0.0000135
+ 2,0.00006984,0.00000761,-0.00001319,-0.00086712,0.00000354,0.00000450,
+ -0.00000884,0.00000200,0.00001082,0.00006854,-0.00087668,0.00242433,-0
+ .03380413,-0.00002037,-0.00005349,-0.00444595,-0.00017745,0.00025685,0
+ .00287501,0.00087631,-0.00263114,0.02358432,-0.02668572,0.00440240,-0.
+ 00005015,0.03009968,-0.00006361,-0.00019743,0.01585709,-0.00577328,0.0
+ 0007927,0.01414956,-0.00040093,-0.00005551,-0.01241726,-0.00846785,0.0
+ 0038109,-0.00622419,0.00930819,-0.00005905,0.00630152,-0.00060141,0.00
+ 009165,-0.00094332,-0.00189626,0.00004406,-0.05224070,-0.01110551,0.00
+ 033757,-0.00010869,0.00004739,0.00001919,-0.40284808,0.02729621,0.0010
+ 0690,0.00208727,0.00088122,-0.00003143,0.82101300,0.00345998,0.0045623
+ 6,-0.00008577,-0.00323610,0.00033595,0.00004333,0.00121068,-0.00982569
+ ,0.00015186,-0.00647352,-0.00903018,0.00016979,0.00199707,0.00138868,-
+ 0.00008537,0.00024066,-0.00034016,-0.00000409,-0.00076883,0.00013994,-
+ 0.00000086,-0.00035401,0.00006045,-0.00002498,-0.04174234,0.00815130,0
+ .00013912,-0.00155486,0.00050982,-0.00000164,0.02780347,-0.13553100,0.
+ 00100054,-0.00042410,0.00182652,-0.00002829,0.00561628,0.87042249,-0.0
+ 0001201,-0.00004830,-0.00110696,0.00000277,-0.00000193,-0.00043762,-0.
+ 00000894,0.00017126,0.00409768,0.00006571,0.00011533,0.00410436,0.0000
+ 1177,-0.00001052,0.00014211,-0.00000259,-0.00000978,0.00000499,-0.0000
+ 1308,0.00000035,-0.00007028,0.00000155,0.00000466,0.00000373,0.0006384
+ 1,-0.00001720,0.00775874,0.00001616,-0.00001060,-0.00029935,0.00133711
+ ,0.00097880,-0.03475408,-0.00001129,-0.00004284,-0.00179481,-0.0042650
+ 5,-0.00929764,0.01908918,-0.04306669,-0.03113260,0.00035524,0.01726070
+ ,-0.00602228,-0.00001939,-0.01344773,0.01820334,0.00001307,-0.40640653
+ ,0.04535016,0.00076851,-0.00869948,-0.00429009,0.00026985,-0.00161761,
+ 0.00611905,-0.00005393,0.00365369,-0.00065267,-0.00000079,-0.00150489,
+ -0.00079905,0.00002946,0.02994296,-0.00878448,-0.00009153,-0.00081299,
+ 0.00049607,-0.00004923,-0.13512381,0.04816012,-0.00019951,-0.00235084,
+ -0.00352181,0.00007804,-0.03837872,0.05160743,-0.00040015,0.76705317,-
+ 0.01443910,0.02174519,-0.00017580,-0.01578578,-0.00713526,0.00037876,0
+ .00460045,-0.01331166,0.00011043,0.00968947,-0.11274176,0.00051823,0.0
+ 0445353,0.00556892,-0.00032271,0.00278225,-0.00296200,0.00000325,-0.00
+ 304519,0.00000985,0.00002652,-0.00155795,0.00018437,-0.00014606,-0.003
+ 97232,-0.03289967,0.00036896,0.00042832,0.00040264,-0.00003025,0.08381
+ 571,-0.29399012,0.00198126,-0.00358594,-0.00216489,0.00010623,0.021218
+ 21,-0.00528838,0.00011171,0.02640937,0.69089522,0.00032085,0.00006043,
+ 0.00248814,0.00009528,0.00020666,0.00607315,-0.00003759,0.00007709,0.0
+ 0262387,0.00089940,0.00028949,-0.04320542,-0.00005655,-0.00005407,-0.0
+ 0029087,-0.00001660,-0.00001501,-0.00000249,0.00000252,-0.00005971,-0.
+ 00051118,0.00006133,-0.00001123,-0.00039968,-0.00001694,0.00031421,-0.
+ 00224722,-0.00001475,-0.00003080,-0.00166799,-0.00058056,0.00213665,-0
+ .05821901,0.00007312,0.00009299,0.00593917,-0.00006628,-0.00002735,0.0
+ 0759081,-0.00221963,-0.00530145,0.10870053,0.00155905,-0.00002993,-0.0
+ 0000366,-0.00163971,-0.00002483,0.00001914,-0.00079308,-0.00149006,0.0
+ 0002232,-0.00045650,-0.00015122,-0.00000248,0.00079246,0.00056102,-0.0
+ 0002262,0.00034513,-0.00044123,0.00000274,-0.00039456,0.00004728,-0.00
+ 000908,-0.00005136,0.00010153,-0.00000631,-0.00348675,0.00397888,-0.00
+ 000622,-0.00040288,0.00016954,-0.00000369,-0.01654230,-0.02905470,0.00
+ 042977,0.00007482,-0.00003176,-0.00000182,-0.20963587,-0.18714993,0.00
+ 337975,0.00204174,-0.00197038,-0.00000068,0.21475053,0.00297500,-0.000
+ 39864,0.00000280,-0.00337257,0.00003688,0.00001969,-0.00149047,0.00119
+ 614,0.00001081,-0.00174530,-0.00073818,0.00000003,0.00127725,0.0009139
+ 4,-0.00003878,0.00070977,-0.00109915,0.00000887,-0.00063930,0.00005269
+ ,-0.00000897,0.00012106,0.00022355,-0.00000300,0.00403553,0.00148043,0
+ .00003008,0.00010654,0.00000125,-0.00001007,0.00190346,0.00972220,-0.0
+ 0019634,0.00019465,0.00033183,-0.00001107,-0.18474372,-0.32990797,0.00
+ 492126,0.00329754,0.00085254,-0.00003759,0.19855499,0.32983786,-0.0000
+ 1897,0.00000204,0.00022502,0.00002087,-0.00000314,-0.00012491,0.000014
+ 02,0.00002128,0.00233209,0.00000692,0.00000098,-0.00097832,-0.00000419
+ ,-0.00000638,0.00002456,-0.00000521,0.00001238,0.00006893,0.00000620,-
+ 0.00000239,-0.00004456,-0.00000137,-0.00000416,0.00001207,-0.00001097,
+ 0.00003121,0.00503143,-0.00000591,-0.00000801,-0.00069518,-0.00008674,
+ -0.00010437,-0.00589868,-0.00000482,-0.00000987,-0.00069818,0.00354233
+ ,0.00510845,-0.00108618,-0.00004107,-0.00002763,-0.00189198,-0.0035276
+ 3,-0.00498309,0.00616692,0.00087539,-0.00014259,-0.00000037,-0.0009249
+ 0,-0.00001849,0.00000338,-0.00005466,0.00003064,-0.00001319,-0.0001189
+ 7,0.00157228,0.00000027,0.00039120,0.00022247,-0.00000647,0.00027787,-
+ 0.00039982,0.00000403,-0.00025467,0.00001229,-0.00000659,0.00005704,0.
+ 00007843,0.00000099,0.00167854,0.00178500,-0.00003622,0.00003061,-0.00
+ 001862,0.00000177,-0.01010078,0.03322651,-0.00027723,-0.00048546,-0.00
+ 135849,0.00001955,-0.14000523,0.14724359,-0.00070552,-0.00493255,-0.00
+ 251105,0.00005844,0.01392270,-0.02109701,0.00010908,0.13997438,-0.0032
+ 4611,0.00049600,-0.00000299,0.00367031,0.00000225,-0.00002947,0.001745
+ 16,-0.00123360,0.00001236,0.00165559,0.00039922,0.00000625,-0.00150958
+ ,-0.00110527,0.00004763,-0.00071501,0.00105399,-0.00000626,0.00072199,
+ -0.00005815,0.00001012,-0.00007067,-0.00019947,0.00000626,-0.00365970,
+ 0.00121653,-0.00001455,-0.00005881,-0.00001054,0.00000395,0.00231666,0
+ .00315417,-0.00010482,0.00032256,-0.00051593,0.00000392,0.14492521,-0.
+ 39914904,0.00316423,-0.00265684,0.00291092,0.00002675,0.01566722,-0.01
+ 173583,-0.00003339,-0.15869162,0.40434523,0.00005856,-0.00000463,0.000
+ 23153,-0.00005751,-0.00000032,-0.00006023,-0.00003625,0.00000818,-0.00
+ 101281,-0.00003411,0.00001059,0.00228192,0.00002451,0.00001706,-0.0000
+ 4415,0.00000605,-0.00001943,-0.00010694,-0.00001145,0.00000404,0.00006
+ 826,0.00000283,0.00000685,0.00004942,0.00004914,-0.00002787,-0.0018801
+ 3,0.00000230,0.00000266,0.00026343,-0.00011189,-0.00016801,-0.00573090
+ ,0.00000175,0.00001474,0.00039388,-0.00053875,0.00295434,-0.00119492,0
+ .00007391,0.00000765,0.00493002,-0.00028049,0.00025632,-0.00311689,0.0
+ 0084512,-0.00304872,0.00624103,-0.00496858,0.00228513,0.00003996,0.000
+ 28316,-0.00167335,0.00003160,-0.00026427,0.00069963,-0.00003643,-0.012
+ 63629,-0.02543839,0.00019907,-0.00098188,0.00002664,-0.00001355,-0.000
+ 13676,0.00022079,-0.00000789,0.00028447,-0.00013887,0.00002409,-0.0000
+ 4891,-0.00022525,0.00001392,-0.00095793,0.00333306,0.00000155,0.000022
+ 69,-0.00007673,0.00000434,0.00905295,0.01341618,-0.00015725,0.00061832
+ ,0.00063146,-0.00001480,0.00193722,0.00036152,-0.00002003,-0.15421415,
+ -0.13809666,0.00159670,-0.00030223,-0.00034129,0.00000974,0.00005253,-
+ 0.00014022,0.00000150,0.16126330,0.00213697,0.00157366,0.00005038,-0.0
+ 0006777,0.00054307,0.00001041,0.00122539,-0.00035556,0.00000445,0.0064
+ 1070,0.00590727,-0.00005291,0.00038778,0.00012136,-0.00001557,-0.00001
+ 719,-0.00005662,0.00000165,-0.00005825,0.00003098,-0.00000605,0.000013
+ 73,0.00004891,0.00000662,0.00333615,-0.00357805,0.00006561,-0.00005268
+ ,0.00005327,-0.00000771,-0.01931752,-0.01563799,0.00021725,-0.00093340
+ ,-0.00078377,0.00001022,-0.00091129,0.00191708,-0.00002830,-0.13905225
+ ,-0.25109932,0.00228089,0.00131399,-0.00072036,0.00000178,0.00008270,0
+ .00034571,-0.00000634,0.14535884,0.26079794,0.00004485,0.00004985,0.00
+ 840127,-0.00001682,0.00002296,0.00176853,-0.00001921,-0.00001517,-0.00
+ 124378,-0.00002950,0.00000618,0.00051717,-0.00000265,0.00000516,-0.000
+ 60246,-0.00000251,-0.00000569,-0.00002183,0.00000269,-0.00001586,-0.00
+ 027746,0.00000542,0.00000418,0.00001047,-0.00000877,0.00009424,0.00588
+ 109,0.00000046,-0.00000665,-0.00058673,0.00012221,0.00018011,0.0027414
+ 2,0.00000405,0.00000212,-0.00059830,0.00002419,-0.00004743,-0.00182242
+ ,0.00158108,0.00221436,-0.03271976,-0.00000758,0.00001132,0.00044572,-
+ 0.00000367,-0.00000664,-0.00070845,-0.00164921,-0.00247816,0.02316210,
+ 0.01104295,-0.01546499,0.00010130,-0.00069482,0.00065135,-0.00005861,-
+ 0.00248287,-0.00323230,0.00003982,-0.09348345,0.09227496,-0.00035410,0
+ .00087437,0.00032606,0.00000698,-0.00221933,-0.00119332,0.00001708,-0.
+ 00033430,0.00009535,-0.00000869,-0.00268050,-0.00084531,-0.00015604,-0
+ .00070419,-0.00019326,0.00002782,0.00060812,-0.00084510,0.00002272,-0.
+ 00655776,-0.00038761,0.00002643,0.00007235,0.00006208,-0.00001053,0.00
+ 035321,0.00188420,-0.00001789,-0.00809134,0.03068389,-0.00012023,0.000
+ 07301,0.00002045,-0.00000070,-0.00047892,-0.00001169,0.00000027,0.0011
+ 4774,0.00010270,-0.00003769,0.10344110,0.01132655,-0.01433270,0.000084
+ 90,0.00433614,-0.00408793,0.00008958,-0.00447761,-0.00182171,0.0000185
+ 5,0.09936660,-0.30092955,0.00119973,-0.00066164,0.00074044,-0.00001846
+ ,0.00071724,0.00438759,-0.00005852,-0.00002444,-0.00018548,-0.00001042
+ ,-0.00390482,0.00048326,-0.00011051,-0.00034353,0.00048971,-0.00000806
+ ,0.00080163,-0.00081422,0.00002311,-0.00013021,0.00161946,0.00003459,0
+ .00009266,-0.00000015,-0.00000353,0.00003730,-0.00020637,-0.00000156,-
+ 0.00289368,-0.00091371,0.00004203,-0.00003466,-0.00002848,0.00000273,-
+ 0.00000776,0.00005527,-0.00000573,-0.00022773,0.00089520,-0.00001835,-
+ 0.10392143,0.31461477,-0.00008344,0.00033742,-0.00019207,-0.00006206,0
+ .00001079,-0.00262188,0.00008378,0.00008476,0.00509301,-0.00023731,0.0
+ 0083843,-0.03081542,0.00004604,0.00001232,-0.00009198,-0.00006737,-0.0
+ 0005882,-0.00019930,-0.00001836,0.00001244,0.00016681,-0.00015740,-0.0
+ 0001744,0.00190095,-0.00001248,-0.00004411,-0.00169136,0.00000578,0.00
+ 002808,0.00122617,0.00000623,0.00006153,0.00948907,-0.00000427,-0.0000
+ 0666,-0.00068424,-0.00001948,0.00000639,-0.00021662,0.00001415,0.00006
+ 540,0.00286172,0.00000299,0.00000308,0.00022324,-0.00000359,-0.0000071
+ 7,-0.00060445,-0.00001125,-0.00005811,-0.00437264,0.00051215,-0.001270
+ 26,0.02052707,-0.00522167,-0.00219180,0.00013664,0.00722020,0.01752913
+ ,-0.00064178,0.00129254,-0.00126949,-0.00001811,0.00114385,0.00149557,
+ -0.00006993,-0.04867774,-0.00512229,-0.00082518,0.00041071,-0.00464691
+ ,0.00013565,0.00846117,0.00048259,-0.00658907,-0.00007235,0.00048206,-
+ 0.00006289,-0.00119396,-0.00101502,0.00005447,0.00028726,-0.00035710,-
+ 0.00002376,0.00270335,-0.00065168,-0.00004126,-0.00009621,0.00000524,-
+ 0.00000366,-0.00275658,0.00032163,0.00001059,-0.00139615,0.00110748,0.
+ 00002554,0.00018408,0.00028595,-0.00000485,0.00012414,-0.00032007,0.00
+ 000177,-0.00015252,0.00004158,-0.00000149,0.00014160,-0.00000115,0.000
+ 00002,0.42525175,0.00021697,0.00099138,-0.00007011,0.00249030,-0.00643
+ 895,0.00033030,-0.00008711,-0.00002335,-0.00001202,-0.00000420,-0.0001
+ 9361,-0.00006279,0.00560228,0.01034308,0.00146685,-0.00183157,0.001595
+ 25,-0.00000896,-0.00262360,-0.01944137,-0.00460118,-0.00023703,0.00022
+ 118,-0.00002331,-0.00006675,0.00006708,0.00001729,-0.00006593,-0.00003
+ 229,-0.00001238,-0.00004338,0.00006065,-0.00002106,-0.00002118,-0.0000
+ 0861,-0.00000230,0.00004620,0.00001509,0.00000235,0.00013261,0.0000613
+ 7,0.00001526,-0.00000330,-0.00001184,0.00000118,-0.00000427,-0.0000047
+ 2,-0.00000058,0.00002407,-0.00000467,0.00000567,0.00000600,0.00009632,
+ -0.00000206,0.07422383,0.58175623,-0.00049993,-0.00001902,-0.00042949,
+ 0.00141352,0.00092619,0.00017076,0.00014118,-0.00011111,0.00016804,0.0
+ 0014988,0.00010231,0.00000233,0.00003471,0.00030071,0.00558748,-0.0003
+ 0022,-0.00034039,0.00036824,-0.00333437,-0.00455144,-0.01144889,-0.000
+ 09638,0.00013175,-0.00017486,-0.00014183,-0.00010039,-0.00004409,0.000
+ 02910,-0.00004274,-0.00003772,0.00027229,-0.00005878,0.00001893,-0.000
+ 00683,-0.00000154,-0.00001717,-0.00027993,0.00003389,0.00002179,-0.000
+ 11684,0.00014237,-0.00003865,0.00001876,0.00002908,-0.00001307,0.00001
+ 275,-0.00003272,-0.00001985,-0.00000767,0.00000575,0.00001160,0.000013
+ 97,0.00000960,-0.00003850,-0.12617110,0.24532847,0.19216613,0.00009445
+ ,-0.00009516,-0.00001164,-0.00001809,0.00018645,-0.00000346,-0.0000320
+ 9,-0.00001805,0.00000418,-0.00004970,-0.00002281,0.00002213,-0.0036369
+ 5,0.00206244,-0.00027820,-0.00003724,-0.00018234,-0.00001598,0.0030391
+ 0,-0.00764803,0.00057082,-0.00005300,0.00008985,-0.00001373,0.00003172
+ ,0.00007260,-0.00000023,-0.00004588,-0.00002302,-0.00001112,-0.0001547
+ 4,0.00001261,0.00000232,-0.00000402,0.00000028,0.00000047,0.00016326,-
+ 0.00001022,-0.00000141,0.00004114,-0.00005801,-0.00000126,-0.00001486,
+ -0.00002178,0.00000116,-0.00001289,0.00001979,0.00000029,0.00000161,-0
+ .00000034,-0.00000133,-0.00001128,0.00000505,0.00000034,-0.21682697,-0
+ .24814420,-0.02813877,0.20685197,0.00068669,0.00010706,-0.00001489,-0.
+ 00157693,-0.00103095,0.00005519,-0.00014403,0.00021750,-0.00000412,-0.
+ 00015429,-0.00017516,0.00002348,0.00582109,-0.00072942,-0.00025509,0.0
+ 0014339,0.00001683,-0.00004866,-0.00768983,0.00390360,0.00066719,0.000
+ 01183,-0.00001473,-0.00000578,0.00017024,0.00011734,-0.00000480,-0.000
+ 00179,0.00006007,0.00000080,-0.00034703,0.00009089,0.00000536,0.000025
+ 35,0.00000242,0.00000227,0.00035861,-0.00005690,-0.00000125,0.00016752
+ ,-0.00017472,0.00000169,-0.00002296,-0.00003204,0.00000069,-0.00001280
+ ,0.00004764,-0.00000029,0.00001584,-0.00000260,-0.00000225,-0.00001729
+ ,-0.00002738,-0.00000306,-0.20356790,-0.33573453,-0.06489285,0.2301398
+ 5,0.35418581,0.00029166,0.00002065,-0.00001670,-0.00066528,-0.00020042
+ ,-0.00006083,-0.00006034,0.00007203,-0.00004444,-0.00007023,-0.0000860
+ 0,-0.00004270,0.00055859,0.00033811,0.00043349,0.00019329,0.00008201,0
+ .00013600,-0.00201537,-0.00043069,-0.00100565,0.00003994,-0.00003418,0
+ .00008925,0.00007805,0.00005723,-0.00001191,-0.00001737,0.00001059,0.0
+ 0005291,-0.00016640,0.00003067,0.00001014,0.00000716,-0.00000121,0.000
+ 01298,0.00016870,-0.00001946,-0.00001445,0.00008380,-0.00007207,0.0000
+ 0182,-0.00001135,-0.00001770,0.00000856,-0.00000762,0.00002023,0.00001
+ 101,0.00000729,-0.00000168,0.00000712,-0.00001054,-0.00000447,0.000016
+ 86,-0.00262320,-0.04008698,-0.01851875,0.02051395,0.06257827,0.0220755
+ 9,0.00028721,-0.00052187,0.00008967,-0.00165885,0.00312726,0.00008275,
+ -0.00006557,0.00013255,-0.00000408,-0.00015136,0.00000032,0.00002863,-
+ 0.00492647,-0.00134193,-0.00149101,0.00089947,-0.00108674,-0.00026927,
+ 0.00586297,0.00356916,0.00595155,0.00014882,-0.00018410,0.00004162,0.0
+ 0013109,0.00006945,-0.00000712,0.00000060,-0.00001551,0.00000538,-0.00
+ 027841,0.00001594,0.00001421,0.00001056,0.00000265,0.00000055,0.000282
+ 55,-0.00003261,-0.00000587,0.00005008,-0.00016630,-0.00000211,-0.00002
+ 340,-0.00003075,0.00000212,-0.00001540,0.00003584,0.00000245,-0.000000
+ 47,0.00000017,-0.00000453,-0.00001571,-0.00005452,0.00000552,-0.170826
+ 48,0.17039029,0.15700772,0.01067446,-0.02400557,-0.01629477,0.15961429
+ ,-0.00039557,-0.00039172,0.00002381,0.00105819,0.00350985,-0.00008563,
+ 0.00009629,-0.00002283,0.00001907,0.00010880,0.00015520,0.00000387,-0.
+ 00454299,-0.00094871,-0.00033442,0.00066594,-0.00154647,-0.00007632,0.
+ 00636834,-0.00064916,0.00087426,-0.00012588,0.00010179,0.00002846,-0.0
+ 0004504,-0.00011335,-0.00000072,0.00004042,-0.00002340,0.00000263,0.00
+ 016750,-0.00004969,0.00000243,0.00000540,0.00000217,-0.00000112,-0.000
+ 17333,0.00000603,-0.00000003,-0.00013748,0.00005046,-0.00000695,0.0000
+ 1051,0.00002318,-0.00000027,0.00000860,-0.00001438,-0.00000051,-0.0000
+ 1464,0.00000448,0.00000007,0.00000527,-0.00003434,0.00000705,0.1231683
+ 7,-0.23331370,-0.17685914,0.02363506,-0.02077073,-0.02225493,-0.149903
+ 75,0.25402533,-0.00028744,-0.00010754,0.00004035,0.00007120,0.00047559
+ ,0.00024681,0.00004828,-0.00008495,-0.00000260,0.00003737,0.00008045,-
+ 0.00001664,-0.00387259,-0.00056584,-0.00024462,-0.00001164,-0.00010587
+ ,-0.00026992,0.00521929,0.00202635,0.00074959,-0.00000016,-0.00000165,
+ 0.00010887,-0.00006056,-0.00003653,-0.00001317,0.00001596,-0.00000689,
+ 0.00003304,0.00012699,-0.00002764,0.00001514,-0.00000746,0.00000248,0.
+ 00000575,-0.00013189,0.00001519,-0.00001572,-0.00007504,0.00004084,-0.
+ 00001498,0.00000815,0.00001327,0.00000941,0.00000510,-0.00001495,0.000
+ 00922,-0.00001168,-0.00000017,0.00000735,0.00000646,0.00000503,0.00002
+ 354,0.13671159,-0.20226364,-0.16773426,0.00736146,0.00189810,-0.003140
+ 30,-0.14515339,0.19865838,0.17020314\\0.00003400,-0.00004694,-0.000013
+ 48,-0.00006992,-0.00015186,-0.00003187,-0.00035454,0.00006058,0.000007
+ 47,-0.00010808,-0.00012780,0.00001223,-0.00001274,-0.00003400,0.000046
+ 73,-0.00016581,0.00010680,0.00003375,0.00007491,0.00005810,-0.00005066
+ ,0.00000489,-0.00004851,-0.00000615,0.00028115,0.00000259,0.00000182,0
+ .00007385,0.00017517,-0.00000125,-0.00001211,0.00031115,-0.00001877,0.
+ 00007451,-0.00008894,0.00000042,-0.00012825,0.00000539,0.00002143,0.00
+ 029007,-0.00029113,0.00000181,-0.00002600,0.00000937,-0.00000376,-0.00
+ 000376,-0.00003925,-0.00000609,0.00004847,0.00001289,-0.00000228,0.000
+ 00450,0.00006347,-0.00000330,-0.00001981,0.00005452,0.00001063,0.00003
+ 318,0.00001697,0.00002629,-0.00001852,-0.00004855,-0.00002496\\\@
+ The archive entry for this job was punched.
+
+
+ Statistics are no substitute for judgment.
+                            -- Henry Clay
+ Job cpu time:       0 days 18 hours 10 minutes 58.2 seconds.
+ Elapsed time:       0 days  0 hours 34 minutes 14.6 seconds.
+ File lengths (MBytes):  RWF=  57795 Int=      0 D2E=      0 Chk=     11 Scr=      1
+ Normal termination of Gaussian 16 at Mon Oct 16 01:27:11 2023.

--- a/tests/data/calculator/gaussian/water_neutral_opt_freq.out
+++ b/tests/data/calculator/gaussian/water_neutral_opt_freq.out
@@ -1,0 +1,1726 @@
+ Entering Gaussian System, Link 0=g16
+ Initial command:
+ /home/eric/data/opt/apps/gaussian/g16A.03/g16/l1.exe "/tmp/Gau-3820744.inp" -scrdir="/tmp/"
+ Entering Link 1 = /home/eric/data/opt/apps/gaussian/g16A.03/g16/l1.exe PID=   3820746.
+  
+ Copyright (c) 1988,1990,1992,1993,1995,1998,2003,2009,2016,
+            Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 16 program.  It is based on
+ the Gaussian(R) 09 system (copyright 2009, Gaussian, Inc.),
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 16, Revision A.03,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, 
+ G. A. Petersson, H. Nakatsuji, X. Li, M. Caricato, A. V. Marenich, 
+ J. Bloino, B. G. Janesko, R. Gomperts, B. Mennucci, H. P. Hratchian, 
+ J. V. Ortiz, A. F. Izmaylov, J. L. Sonnenberg, D. Williams-Young, 
+ F. Ding, F. Lipparini, F. Egidi, J. Goings, B. Peng, A. Petrone, 
+ T. Henderson, D. Ranasinghe, V. G. Zakrzewski, J. Gao, N. Rega, 
+ G. Zheng, W. Liang, M. Hada, M. Ehara, K. Toyota, R. Fukuda, 
+ J. Hasegawa, M. Ishida, T. Nakajima, Y. Honda, O. Kitao, H. Nakai, 
+ T. Vreven, K. Throssell, J. A. Montgomery, Jr., J. E. Peralta, 
+ F. Ogliaro, M. J. Bearpark, J. J. Heyd, E. N. Brothers, K. N. Kudin, 
+ V. N. Staroverov, T. A. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. P. Rendell, J. C. Burant, S. S. Iyengar, 
+ J. Tomasi, M. Cossi, J. M. Millam, M. Klene, C. Adamo, R. Cammi, 
+ J. W. Ochterski, R. L. Martin, K. Morokuma, O. Farkas, 
+ J. B. Foresman, and D. J. Fox, Gaussian, Inc., Wallingford CT, 2016.
+ 
+ ******************************************
+ Gaussian 16:  ES64L-G16RevA.03 25-Dec-2016
+                 6-May-2025 
+ ******************************************
+ %chk=water_neutral_nbo_opt_freq.chk
+ ----------------------------
+ # hf/sto-3g opt freq pop=nbo
+ ----------------------------
+ 1/18=20,19=15,38=1/1,3;
+ 2/9=110,12=2,17=6,18=5,40=1/2;
+ 3/6=3,11=9,25=1,30=1,71=1/1,2,3;
+ 4//1;
+ 5/5=2,38=5/2;
+ 6/7=2,8=2,9=2,10=2,28=1,40=1/1,7;
+ 7//1,2,3,16;
+ 1/18=20,19=15/3(2);
+ 2/9=110/2;
+ 99//99;
+ 2/9=110/2;
+ 3/6=3,11=9,25=1,30=1,71=1/1,2,3;
+ 4/5=5,16=3,69=1/1;
+ 5/5=2,38=5/2;
+ 7//1,2,3,16;
+ 1/18=20,19=15/3(-5);
+ 2/9=110/2;
+ 6/7=2,8=2,9=2,10=2,19=2,28=1,40=1/1,7;
+ 99/9=1/99;
+ -----
+ Water
+ -----
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 1
+ O
+ H                    1    R1
+ H                    1    R1       2    A1
+       Variables:
+  R1                    0.99                     
+  A1                  106.                       
+ 
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+                           ----------------------------
+                           !    Initial Parameters    !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.99           estimate D2E/DX2                !
+ ! R2    R(1,3)                  0.99           estimate D2E/DX2                !
+ ! A1    A(2,1,3)              106.0            estimate D2E/DX2                !
+ --------------------------------------------------------------------------------
+ Trust Radius=3.00D-01 FncErr=1.00D-07 GrdErr=1.00D-07 EigMax=2.50D+02 EigMin=1.00D-04
+ Number of steps in this run=     20 maximum allowed number of steps=    100.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.000000    0.000000
+      2          1           0        0.000000    0.000000    0.990000
+      3          1           0        0.951649    0.000000   -0.272881
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.990000   0.000000
+     3  H    0.990000   1.581298   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.000000    0.119159
+      2          1           0       -0.000000    0.790649   -0.476637
+      3          1           0       -0.000000   -0.790649   -0.476637
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         795.3367043         401.0831699         266.6255997
+ Standard basis: STO-3G (5D, 7F)
+ There are     4 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     0 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     2 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are     4 symmetry adapted basis functions of A1  symmetry.
+ There are     0 symmetry adapted basis functions of A2  symmetry.
+ There are     1 symmetry adapted basis functions of B1  symmetry.
+ There are     2 symmetry adapted basis functions of B2  symmetry.
+     7 basis functions,    21 primitive gaussians,     7 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         8.8870062650 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=     7 RedAO= T EigKep=  3.64D-01  NBF=     4     0     1     2
+ NBsUse=     7 1.00D-06 EigRej= -1.00D+00 NBFU=     4     0     1     2
+ ExpMin= 1.69D-01 ExpMax= 1.31D+02 ExpMxC= 1.31D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor=  205 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor=  205 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2)
+ The electronic state of the initial guess is 1-A1.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=803110.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -74.9643287914     A.U. after    7 cycles
+            NFock=  7  Conv=0.28D-09     -V/T= 2.0060
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2)
+ The electronic state is 1-A1.
+ Alpha  occ. eigenvalues --  -20.24375  -1.25064  -0.60317  -0.44547  -0.38821
+ Alpha virt. eigenvalues --    0.57075   0.70859
+          Condensed to atoms (all electrons):
+               1          2          3
+     1  O    7.824444   0.257385   0.257385
+     2  H    0.257385   0.614637  -0.041629
+     3  H    0.257385  -0.041629   0.614637
+ Mulliken charges:
+               1
+     1  O   -0.339215
+     2  H    0.169607
+     3  H    0.169607
+ Sum of Mulliken charges =  -0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  O   -0.000000
+ Electronic spatial extent (au):  <R**2>=             18.2650
+ Charge=             -0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=             -0.0000    Y=              0.0000    Z=             -1.6735  Tot=              1.6735
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -6.1213   YY=             -4.2950   ZZ=             -5.4175
+   XY=              0.0000   XZ=              0.0000   YZ=             -0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -0.8434   YY=              0.9829   ZZ=             -0.1396
+   XY=              0.0000   XZ=              0.0000   YZ=             -0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=              0.0000  YYY=             -0.0000  ZZZ=             -0.1457  XYY=             -0.0000
+  XXY=             -0.0000  XXZ=              0.0136  XZZ=              0.0000  YZZ=             -0.0000
+  YYZ=             -0.5848  XYZ=             -0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=             -3.2614 YYYY=             -6.8264 ZZZZ=             -4.9965 XXXY=             -0.0000
+ XXXZ=             -0.0000 YYYX=             -0.0000 YYYZ=             -0.0000 ZZZX=             -0.0000
+ ZZZY=             -0.0000 XXYY=             -1.8585 XXZZ=             -1.4123 YYZZ=             -1.7504
+ XXYZ=             -0.0000 YYXZ=              0.0000 ZZXY=             -0.0000
+ N-N= 8.887006265008D+00 E-N=-1.963570298436D+02  KE= 7.451686029031D+01
+ Symmetry A1   KE= 6.656897033954D+01
+ Symmetry A2   KE= 0.000000000000D+00
+ Symmetry B1   KE= 5.057462452019D+00
+ Symmetry B2   KE= 2.890427498754D+00
+ ******************************Gaussian NBO Version 3.1******************************
+             N A T U R A L   A T O M I C   O R B I T A L   A N D
+          N A T U R A L   B O N D   O R B I T A L   A N A L Y S I S
+ ******************************Gaussian NBO Version 3.1******************************
+       /RESON  / : Allow strongly delocalized NBO set
+
+ Analyzing the SCF density
+
+ Job title: Water                                                           
+
+ Storage needed:       205 in NPA,       237 in NBO ( 104857537 available)
+
+
+ NATURAL POPULATIONS:  Natural atomic orbital occupancies 
+                                                          
+   NAO  Atom  No  lang   Type(AO)    Occupancy      Energy
+ ----------------------------------------------------------
+     1    O    1  S      Cor( 1S)     2.00000     -20.14104
+     2    O    1  S      Val( 2S)     1.76109      -1.02099
+     3    O    1  px     Val( 2p)     2.00000      -0.38821
+     4    O    1  py     Val( 2p)     1.13227      -0.03404
+     5    O    1  pz     Val( 2p)     1.48331      -0.19862
+ 
+     6    H    2  S      Val( 1S)     0.81167       0.06550
+ 
+     7    H    3  S      Val( 1S)     0.81167       0.06550
+
+
+ Summary of Natural Population Analysis:                  
+                                                          
+                                       Natural Population 
+                Natural  -----------------------------------------------
+    Atom  No    Charge         Core      Valence    Rydberg      Total
+ -----------------------------------------------------------------------
+      O    1   -0.37667      2.00000     6.37667    0.00000     8.37667
+      H    2    0.18833      0.00000     0.81167    0.00000     0.81167
+      H    3    0.18833      0.00000     0.81167    0.00000     0.81167
+ =======================================================================
+   * Total *   -0.00000      2.00000     8.00000    0.00000    10.00000
+
+                                 Natural Population      
+ --------------------------------------------------------
+   Core                       2.00000 (100.0000% of   2)
+   Valence                    8.00000 (100.0000% of   8)
+   Natural Minimal Basis     10.00000 (100.0000% of  10)
+   Natural Rydberg Basis      0.00000 (  0.0000% of  10)
+ --------------------------------------------------------
+
+    Atom  No          Natural Electron Configuration
+ ----------------------------------------------------------------------------
+      O    1      [core]2S( 1.76)2p( 4.62)
+      H    2            1S( 0.81)
+      H    3            1S( 0.81)
+
+
+ NATURAL BOND ORBITAL ANALYSIS:
+
+                       Occupancies       Lewis Structure    Low   High
+           Occ.    -------------------  -----------------   occ   occ
+  Cycle   Thresh.   Lewis   Non-Lewis     CR  BD  3C  LP    (L)   (NL)   Dev
+ =============================================================================
+   1(1)    1.90     9.99674   0.00326      1   2   0   2     0      0    0.00
+ -----------------------------------------------------------------------------
+
+ Structure accepted: No low occupancy Lewis orbitals
+
+ --------------------------------------------------------
+   Core                      2.00000 (100.000% of   2)
+   Valence Lewis             7.99674 ( 99.959% of   8)
+  ==================       ============================
+   Total Lewis               9.99674 ( 99.967% of  10)
+  -----------------------------------------------------
+   Valence non-Lewis         0.00326 (  0.033% of  10)
+   Rydberg non-Lewis         0.00000 (  0.000% of  10)
+  ==================       ============================
+   Total non-Lewis           0.00326 (  0.033% of  10)
+ --------------------------------------------------------
+
+
+       (Occupancy)   Bond orbital/ Coefficients/ Hybrids
+ ---------------------------------------------------------------------------------
+     1. (1.99837) BD ( 1) O   1 - H   2  
+                ( 59.43%)   0.7709* O   1 s( 15.81%)p 5.33( 84.19%)
+                                            0.0000  0.3976  0.0000  0.7071 -0.5847
+                ( 40.57%)   0.6369* H   2 s(100.00%)
+                                            1.0000
+     2. (1.99837) BD ( 1) O   1 - H   3  
+                ( 59.43%)   0.7709* O   1 s( 15.81%)p 5.33( 84.19%)
+                                            0.0000 -0.3976  0.0000  0.7071  0.5847
+                ( 40.57%)   0.6369* H   3 s(100.00%)
+                                           -1.0000
+     3. (2.00000) CR ( 1) O   1           s(100.00%)
+                                            1.0000  0.0000  0.0000  0.0000  0.0000
+     4. (2.00000) LP ( 1) O   1           s( 68.38%)p 0.46( 31.62%)
+                                            0.0000  0.8269  0.0000  0.0000  0.5623
+     5. (2.00000) LP ( 2) O   1           s(  0.00%)p 1.00(100.00%)
+                                            0.0000  0.0000  1.0000  0.0000  0.0000
+     6. (0.00163) BD*( 1) O   1 - H   2  
+                ( 40.57%)   0.6369* O   1 s( 15.81%)p 5.33( 84.19%)
+                                           -0.0000 -0.3976 -0.0000 -0.7071  0.5847
+                ( 59.43%)  -0.7709* H   2 s(100.00%)
+                                           -1.0000
+     7. (0.00163) BD*( 1) O   1 - H   3  
+                ( 40.57%)   0.6369* O   1 s( 15.81%)p 5.33( 84.19%)
+                                           -0.0000  0.3976 -0.0000 -0.7071 -0.5847
+                ( 59.43%)  -0.7709* H   3 s(100.00%)
+                                            1.0000
+
+
+ NHO Directionality and "Bond Bending" (deviations from line of nuclear centers)
+
+         [Thresholds for printing:  angular deviation  >  1.0 degree]
+                                    hybrid p-character > 25.0%
+                                    orbital occupancy  >  0.10e
+
+                                Line of Centers        Hybrid 1              Hybrid 2
+                                ---------------  -------------------   ------------------
+                NBO               Theta   Phi    Theta   Phi    Dev    Theta   Phi    Dev
+ ========================================================================================
+     1. BD (   1) O   1 - H   2   127.0   90.0   129.6   90.0   2.6      --     --    --
+     2. BD (   1) O   1 - H   3   127.0  270.0   129.6  270.0   2.6      --     --    --
+     4. LP (   1) O   1             --     --      0.0    0.0   --       --     --    --
+     5. LP (   2) O   1             --     --     90.0    0.0   --       --     --    --
+
+
+ Second Order Perturbation Theory Analysis of Fock Matrix in NBO Basis
+
+     Threshold for printing:   0.50 kcal/mol
+                                                                              E(2)  E(j)-E(i) F(i,j)
+         Donor NBO (i)                     Acceptor NBO (j)                 kcal/mol   a.u.    a.u. 
+ ===================================================================================================
+
+ within unit  1
+   1. BD (   1) O   1 - H   2        /  7. BD*(   1) O   1 - H   3            1.46    1.42    0.041
+   2. BD (   1) O   1 - H   3        /  6. BD*(   1) O   1 - H   2            1.46    1.42    0.041
+
+
+ Natural Bond Orbitals (Summary):
+
+                                                            Principal Delocalizations
+           NBO                        Occupancy    Energy   (geminal,vicinal,remote)
+ ====================================================================================
+ Molecular unit  1  (H2O)
+     1. BD (   1) O   1 - H   2          1.99837    -0.78162  7(g)
+     2. BD (   1) O   1 - H   3          1.99837    -0.78162  6(g)
+     3. CR (   1) O   1                  2.00000   -20.14104   
+     4. LP (   1) O   1                  2.00000    -0.83644   
+     5. LP (   2) O   1                  2.00000    -0.38821   
+     6. BD*(   1) O   1 - H   2          0.00163     0.63851   
+     7. BD*(   1) O   1 - H   3          0.00163     0.63851   
+       -------------------------------
+              Total Lewis    9.99674  ( 99.9674%)
+        Valence non-Lewis    0.00326  (  0.0326%)
+        Rydberg non-Lewis    0.00000  (  0.0000%)
+       -------------------------------
+            Total unit  1   10.00000  (100.0000%)
+           Charge unit  1    0.00000
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.015934910    0.000000000   -0.012007816
+      2        1           0.015814759   -0.000000000   -0.004409816
+      3        1           0.000120151   -0.000000000    0.016417632
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.016417632 RMS     0.010204657
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.029586707 RMS     0.017457245
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.49491
+           R2           0.00000   0.49491
+           A1           0.00000   0.00000   0.16000
+ ITU=  0
+     Eigenvalues ---    0.16000   0.49491   0.49491
+ RFO step:  Lambda=-5.37112308D-03 EMin= 1.60000000D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.10662776 RMS(Int)=  0.00612155
+ Iteration  2 RMS(Cart)=  0.00508857 RMS(Int)=  0.00000026
+ Iteration  3 RMS(Cart)=  0.00000027 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 1.64D-15 for atom     1.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.87083  -0.00441   0.00000  -0.00881  -0.00881   1.86201
+    R2        1.87083  -0.00441   0.00000  -0.00881  -0.00881   1.86201
+    A1        1.85005  -0.02959   0.00000  -0.17891  -0.17891   1.67114
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.029587     0.000450     NO 
+ RMS     Force            0.017457     0.000300     NO 
+ Maximum Displacement     0.115009     0.001800     NO 
+ RMS     Displacement     0.109053     0.001200     NO 
+ Predicted change in Energy=-2.771944D-03
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.034673   -0.000000   -0.026128
+      2          1           0        0.053353   -0.000000    0.955268
+      3          1           0        0.932969    0.000000   -0.212021
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.985335   0.000000
+     3  H    0.985335   1.461604   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000    0.000000    0.132184
+      2          1           0        0.000000    0.730802   -0.528736
+      3          1           0       -0.000000   -0.730802   -0.528736
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         646.3242312         469.4644440         271.9388112
+ Standard basis: STO-3G (5D, 7F)
+ There are     4 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     0 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     2 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are     4 symmetry adapted basis functions of A1  symmetry.
+ There are     0 symmetry adapted basis functions of A2  symmetry.
+ There are     1 symmetry adapted basis functions of B1  symmetry.
+ There are     2 symmetry adapted basis functions of B2  symmetry.
+     7 basis functions,    21 primitive gaussians,     7 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         8.9548981374 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=     7 RedAO= T EigKep=  3.61D-01  NBF=     4     0     1     2
+ NBsUse=     7 1.00D-06 EigRej= -1.00D+00 NBFU=     4     0     1     2
+ Initial guess from the checkpoint file:  "water_neutral_nbo_opt_freq.chk"
+ B after Tr=     0.000000   -0.000000   -0.000000
+         Rot=    1.000000   -0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2)
+ ExpMin= 1.69D-01 ExpMax= 1.31D+02 ExpMxC= 1.31D+02 IAcc=2 IRadAn=         4 AccDes= 0.00D+00
+ Harris functional with IExCor=  205 and IRadAn=       4 diagonalized for initial guess.
+ HarFok:  IExCor=  205 AccDes= 0.00D+00 IRadAn=         4 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=803110.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -74.9649723283     A.U. after    7 cycles
+            NFock=  7  Conv=0.26D-10     -V/T= 2.0058
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.006553280    0.000000000    0.004938251
+      2        1          -0.011892763   -0.000000000    0.008964856
+      3        1           0.005339483   -0.000000000   -0.013903106
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.013903106 RMS     0.007534695
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.023547209 RMS     0.015035918
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Update second derivatives using D2CorX and points    1    2
+ DE= -6.44D-04 DEPred=-2.77D-03 R= 2.32D-01
+ Trust test= 2.32D-01 RLast= 1.79D-01 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50675
+           R2           0.01184   0.50675
+           A1           0.04307   0.04307   0.29274
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.27736   0.49491   0.53396
+ RFO step:  Lambda=-2.70205181D-05 EMin= 2.77363382D-01
+ Quartic linear search produced a step of -0.42733.
+ Iteration  1 RMS(Cart)=  0.04813404 RMS(Int)=  0.00106117
+ Iteration  2 RMS(Cart)=  0.00079477 RMS(Int)=  0.00000015
+ Iteration  3 RMS(Cart)=  0.00000017 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 1.86D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.86201   0.00787   0.00377   0.00515   0.00891   1.87093
+    R2        1.86201   0.00787   0.00377   0.00515   0.00891   1.87093
+    A1        1.67114   0.02355   0.07645  -0.00238   0.07408   1.74521
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.023547     0.000450     NO 
+ RMS     Force            0.015036     0.000300     NO 
+ Maximum Displacement     0.050913     0.001800     NO 
+ RMS     Displacement     0.047825     0.001200     NO 
+ Predicted change in Energy=-9.832722D-04
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.021638   -0.000000   -0.016305
+      2          1           0        0.030235   -0.000000    0.972387
+      3          1           0        0.943052    0.000000   -0.238963
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.990052   0.000000
+     3  H    0.990052   1.516774   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000    0.000000    0.127287
+      2          1           0        0.000000    0.758387   -0.509150
+      3          1           0       -0.000000   -0.758387   -0.509150
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         697.0061687         435.9333468         268.1945750
+ Standard basis: STO-3G (5D, 7F)
+ There are     4 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     0 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     2 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are     4 symmetry adapted basis functions of A1  symmetry.
+ There are     0 symmetry adapted basis functions of A2  symmetry.
+ There are     1 symmetry adapted basis functions of B1  symmetry.
+ There are     2 symmetry adapted basis functions of B2  symmetry.
+     7 basis functions,    21 primitive gaussians,     7 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         8.9007921173 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=     7 RedAO= T EigKep=  3.64D-01  NBF=     4     0     1     2
+ NBsUse=     7 1.00D-06 EigRej= -1.00D+00 NBFU=     4     0     1     2
+ Initial guess from the checkpoint file:  "water_neutral_nbo_opt_freq.chk"
+ B after Tr=    -0.000000   -0.000000    0.000000
+         Rot=    1.000000   -0.000000   -0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2)
+ ExpMin= 1.69D-01 ExpMax= 1.31D+02 ExpMxC= 1.31D+02 IAcc=2 IRadAn=         4 AccDes= 0.00D+00
+ Harris functional with IExCor=  205 and IRadAn=       4 diagonalized for initial guess.
+ HarFok:  IExCor=  205 AccDes= 0.00D+00 IRadAn=         4 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=803110.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -74.9659003010     A.U. after    6 cycles
+            NFock=  6  Conv=0.14D-08     -V/T= 2.0060
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.000807283    0.000000000    0.000608332
+      2        1          -0.000082265   -0.000000000   -0.000730647
+      3        1          -0.000725018   -0.000000000    0.000122316
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000807283 RMS     0.000483391
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000733954 RMS     0.000601141
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    1    2    3
+ DE= -9.28D-04 DEPred=-9.83D-04 R= 9.44D-01
+ TightC=F SS=  1.41D+00  RLast= 7.51D-02 DXNew= 5.0454D-01 2.2542D-01
+ Trust test= 9.44D-01 RLast= 7.51D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.51383
+           R2           0.01892   0.51383
+           A1           0.05200   0.05200   0.30426
+ ITU=  1  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.28264   0.49491   0.55438
+ RFO step:  Lambda=-2.16452489D-06 EMin= 2.82635873D-01
+ Quartic linear search produced a step of -0.00383.
+ Iteration  1 RMS(Cart)=  0.00087864 RMS(Int)=  0.00000036
+ Iteration  2 RMS(Cart)=  0.00000041 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 1.96D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.87093  -0.00073  -0.00003  -0.00142  -0.00145   1.86948
+    R2        1.87093  -0.00073  -0.00003  -0.00142  -0.00145   1.86948
+    A1        1.74521   0.00008  -0.00028   0.00104   0.00076   1.74597
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000734     0.000450     NO 
+ RMS     Force            0.000601     0.000300     NO 
+ Maximum Displacement     0.000822     0.001800     YES
+ RMS     Displacement     0.000879     0.001200     YES
+ Predicted change in Energy=-1.097462D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.021222   -0.000000   -0.015992
+      2          1           0        0.030237   -0.000000    0.971952
+      3          1           0        0.942635    0.000000   -0.238841
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.989284   0.000000
+     3  H    0.989284   1.516077   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000    0.000000    0.127131
+      2          1           0       -0.000000    0.758039   -0.508525
+      3          1           0       -0.000000   -0.758039   -0.508525
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         698.7184174         436.3342031         268.5996564
+ Standard basis: STO-3G (5D, 7F)
+ There are     4 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     0 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     2 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are     4 symmetry adapted basis functions of A1  symmetry.
+ There are     0 symmetry adapted basis functions of A2  symmetry.
+ There are     1 symmetry adapted basis functions of B1  symmetry.
+ There are     2 symmetry adapted basis functions of B2  symmetry.
+     7 basis functions,    21 primitive gaussians,     7 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         8.9075952494 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=     7 RedAO= T EigKep=  3.63D-01  NBF=     4     0     1     2
+ NBsUse=     7 1.00D-06 EigRej= -1.00D+00 NBFU=     4     0     1     2
+ Initial guess from the checkpoint file:  "water_neutral_nbo_opt_freq.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=803110.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -74.9659011806     A.U. after    6 cycles
+            NFock=  6  Conv=0.55D-11     -V/T= 2.0060
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.000166866    0.000000000   -0.000125743
+      2        1           0.000024915   -0.000000000    0.000140528
+      3        1           0.000141952   -0.000000000   -0.000014785
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000166866 RMS     0.000096835
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000141634 RMS     0.000117188
+ Search for a local minimum.
+ Step number   4 out of a maximum of   20
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points    1    2    3    4
+ DE= -8.80D-07 DEPred=-1.10D-06 R= 8.01D-01
+ TightC=F SS=  1.41D+00  RLast= 2.19D-03 DXNew= 5.0454D-01 6.5646D-03
+ Trust test= 8.01D-01 RLast= 2.19D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.55941
+           R2           0.06450   0.55941
+           A1           0.04026   0.04026   0.30687
+ ITU=  1  1  0  0
+     Eigenvalues ---    0.29695   0.49491   0.63383
+ En-DIIS/RFO-DIIS/Sim-DIIS IScMMF=       -3 using points:     4    3
+ RFO step:  Lambda=-7.29690300D-08.
+ DidBck=F Rises=F RFO-DIIS coefs:    0.82893    0.17107
+ Iteration  1 RMS(Cart)=  0.00014506 RMS(Int)=  0.00000001
+ Iteration  2 RMS(Cart)=  0.00000002 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 8.72D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.86948   0.00014   0.00025  -0.00001   0.00024   1.86971
+    R2        1.86948   0.00014   0.00025  -0.00001   0.00024   1.86971
+    A1        1.74597  -0.00003  -0.00013  -0.00004  -0.00017   1.74580
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000142     0.000450     YES
+ RMS     Force            0.000117     0.000300     YES
+ Maximum Displacement     0.000146     0.001800     YES
+ RMS     Displacement     0.000145     0.001200     YES
+ Predicted change in Energy=-3.648451D-08
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9893         -DE/DX =    0.0001              !
+ ! R2    R(1,3)                  0.9893         -DE/DX =    0.0001              !
+ ! A1    A(2,1,3)              100.0367         -DE/DX =    0.0                 !
+ --------------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.021222   -0.000000   -0.015992
+      2          1           0        0.030237   -0.000000    0.971952
+      3          1           0        0.942635    0.000000   -0.238841
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.989284   0.000000
+     3  H    0.989284   1.516077   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000    0.000000    0.127131
+      2          1           0        0.000000    0.758039   -0.508525
+      3          1           0       -0.000000   -0.758039   -0.508525
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         698.7184174         436.3342031         268.5996564
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2)
+ The electronic state is 1-A1.
+ Alpha  occ. eigenvalues --  -20.25155  -1.25760  -0.59393  -0.45972  -0.39262
+ Alpha virt. eigenvalues --    0.58190   0.69284
+          Condensed to atoms (all electrons):
+               1          2          3
+     1  O    7.822822   0.253915   0.253915
+     2  H    0.253915   0.626174  -0.045416
+     3  H    0.253915  -0.045416   0.626174
+ Mulliken charges:
+               1
+     1  O   -0.330652
+     2  H    0.165326
+     3  H    0.165326
+ Sum of Mulliken charges =  -0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  O   -0.000000
+ Electronic spatial extent (au):  <R**2>=             18.2669
+ Charge=             -0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=             -0.0000    Y=              0.0000    Z=             -1.7093  Tot=              1.7093
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -6.1255   YY=             -4.4853   ZZ=             -5.3334
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -0.8108   YY=              0.8294   ZZ=             -0.0186
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=              0.0000  YYY=             -0.0000  ZZZ=             -0.1746  XYY=             -0.0000
+  XXY=             -0.0000  XXZ=              0.0191  XZZ=              0.0000  YZZ=             -0.0000
+  YYZ=             -0.5315  XYZ=             -0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=             -3.2652 YYYY=             -6.7325 ZZZZ=             -5.2185 XXXY=             -0.0000
+ XXXZ=             -0.0000 YYYX=             -0.0000 YYYZ=              0.0000 ZZZX=             -0.0000
+ ZZZY=              0.0000 XXYY=             -1.8083 XXZZ=             -1.4595 YYZZ=             -1.7388
+ XXYZ=              0.0000 YYXZ=              0.0000 ZZXY=             -0.0000
+ N-N= 8.907595249426D+00 E-N=-1.963550185162D+02  KE= 7.451886834874D+01
+ Symmetry A1   KE= 6.651724437958D+01
+ Symmetry A2   KE= 0.000000000000D+00
+ Symmetry B1   KE= 5.057462452019D+00
+ Symmetry B2   KE= 2.944161517138D+00
+ ******************************Gaussian NBO Version 3.1******************************
+             N A T U R A L   A T O M I C   O R B I T A L   A N D
+          N A T U R A L   B O N D   O R B I T A L   A N A L Y S I S
+ ******************************Gaussian NBO Version 3.1******************************
+       /RESON  / : Allow strongly delocalized NBO set
+
+ Analyzing the SCF density
+
+ Job title: Water                                                           
+
+ Storage needed:       205 in NPA,       237 in NBO ( 104857537 available)
+
+
+ NATURAL POPULATIONS:  Natural atomic orbital occupancies 
+                                                          
+   NAO  Atom  No  lang   Type(AO)    Occupancy      Energy
+ ----------------------------------------------------------
+     1    O    1  S      Cor( 1S)     2.00000     -20.14560
+     2    O    1  S      Val( 2S)     1.77260      -1.03262
+     3    O    1  px     Val( 2p)     2.00000      -0.39262
+     4    O    1  py     Val( 2p)     1.14704      -0.04515
+     5    O    1  pz     Val( 2p)     1.44634      -0.18846
+ 
+     6    H    2  S      Val( 1S)     0.81700       0.06189
+ 
+     7    H    3  S      Val( 1S)     0.81700       0.06189
+
+
+ Summary of Natural Population Analysis:                  
+                                                          
+                                       Natural Population 
+                Natural  -----------------------------------------------
+    Atom  No    Charge         Core      Valence    Rydberg      Total
+ -----------------------------------------------------------------------
+      O    1   -0.36599      2.00000     6.36599    0.00000     8.36599
+      H    2    0.18300      0.00000     0.81700    0.00000     0.81700
+      H    3    0.18300      0.00000     0.81700    0.00000     0.81700
+ =======================================================================
+   * Total *   -0.00000      2.00000     8.00000    0.00000    10.00000
+
+                                 Natural Population      
+ --------------------------------------------------------
+   Core                       2.00000 (100.0000% of   2)
+   Valence                    8.00000 (100.0000% of   8)
+   Natural Minimal Basis     10.00000 (100.0000% of  10)
+   Natural Rydberg Basis      0.00000 (  0.0000% of  10)
+ --------------------------------------------------------
+
+    Atom  No          Natural Electron Configuration
+ ----------------------------------------------------------------------------
+      O    1      [core]2S( 1.77)2p( 4.59)
+      H    2            1S( 0.82)
+      H    3            1S( 0.82)
+
+
+ NATURAL BOND ORBITAL ANALYSIS:
+
+                       Occupancies       Lewis Structure    Low   High
+           Occ.    -------------------  -----------------   occ   occ
+  Cycle   Thresh.   Lewis   Non-Lewis     CR  BD  3C  LP    (L)   (NL)   Dev
+ =============================================================================
+   1(1)    1.90     9.99866   0.00134      1   2   0   2     0      0    0.00
+ -----------------------------------------------------------------------------
+
+ Structure accepted: No low occupancy Lewis orbitals
+
+ --------------------------------------------------------
+   Core                      2.00000 (100.000% of   2)
+   Valence Lewis             7.99866 ( 99.983% of   8)
+  ==================       ============================
+   Total Lewis               9.99866 ( 99.987% of  10)
+  -----------------------------------------------------
+   Valence non-Lewis         0.00134 (  0.013% of  10)
+   Rydberg non-Lewis         0.00000 (  0.000% of  10)
+  ==================       ============================
+   Total non-Lewis           0.00134 (  0.013% of  10)
+ --------------------------------------------------------
+
+
+       (Occupancy)   Bond orbital/ Coefficients/ Hybrids
+ ---------------------------------------------------------------------------------
+     1. (1.99933) BD ( 1) O   1 - H   2  
+                ( 59.16%)   0.7691* O   1 s( 14.56%)p 5.87( 85.44%)
+                                            0.0000  0.3815  0.0000  0.7071 -0.5953
+                ( 40.84%)   0.6391* H   2 s(100.00%)
+                                            1.0000
+     2. (1.99933) BD ( 1) O   1 - H   3  
+                ( 59.16%)   0.7691* O   1 s( 14.56%)p 5.87( 85.44%)
+                                            0.0000 -0.3815  0.0000  0.7071  0.5953
+                ( 40.84%)   0.6391* H   3 s(100.00%)
+                                           -1.0000
+     3. (2.00000) CR ( 1) O   1           s(100.00%)
+                                            1.0000  0.0000  0.0000  0.0000  0.0000
+     4. (2.00000) LP ( 1) O   1           s( 70.89%)p 0.41( 29.11%)
+                                            0.0000  0.8419  0.0000  0.0000  0.5396
+     5. (2.00000) LP ( 2) O   1           s(  0.00%)p 1.00(100.00%)
+                                            0.0000  0.0000  1.0000  0.0000  0.0000
+     6. (0.00067) BD*( 1) O   1 - H   2  
+                ( 40.84%)   0.6391* O   1 s( 14.56%)p 5.87( 85.44%)
+                                           -0.0000 -0.3815 -0.0000 -0.7071  0.5953
+                ( 59.16%)  -0.7691* H   2 s(100.00%)
+                                           -1.0000
+     7. (0.00067) BD*( 1) O   1 - H   3  
+                ( 40.84%)   0.6391* O   1 s( 14.56%)p 5.87( 85.44%)
+                                           -0.0000  0.3815 -0.0000 -0.7071 -0.5953
+                ( 59.16%)  -0.7691* H   3 s(100.00%)
+                                            1.0000
+
+
+ NHO Directionality and "Bond Bending" (deviations from line of nuclear centers)
+
+         [Thresholds for printing:  angular deviation  >  1.0 degree]
+                                    hybrid p-character > 25.0%
+                                    orbital occupancy  >  0.10e
+
+                                Line of Centers        Hybrid 1              Hybrid 2
+                                ---------------  -------------------   ------------------
+                NBO               Theta   Phi    Theta   Phi    Dev    Theta   Phi    Dev
+ ========================================================================================
+     4. LP (   1) O   1             --     --      0.0    0.0   --       --     --    --
+     5. LP (   2) O   1             --     --     90.0    0.0   --       --     --    --
+
+
+ Second Order Perturbation Theory Analysis of Fock Matrix in NBO Basis
+
+     Threshold for printing:   0.50 kcal/mol
+                                                                              E(2)  E(j)-E(i) F(i,j)
+         Donor NBO (i)                     Acceptor NBO (j)                 kcal/mol   a.u.    a.u. 
+ ===================================================================================================
+
+ within unit  1
+   1. BD (   1) O   1 - H   2        /  7. BD*(   1) O   1 - H   3            0.59    1.41    0.026
+   2. BD (   1) O   1 - H   3        /  6. BD*(   1) O   1 - H   2            0.59    1.41    0.026
+
+
+ Natural Bond Orbitals (Summary):
+
+                                                            Principal Delocalizations
+           NBO                        Occupancy    Energy   (geminal,vicinal,remote)
+ ====================================================================================
+ Molecular unit  1  (H2O)
+     1. BD (   1) O   1 - H   2          1.99933    -0.77653  7(g)
+     2. BD (   1) O   1 - H   3          1.99933    -0.77653  6(g)
+     3. CR (   1) O   1                  2.00000   -20.14560   
+     4. LP (   1) O   1                  2.00000    -0.86319   
+     5. LP (   2) O   1                  2.00000    -0.39262   
+     6. BD*(   1) O   1 - H   2          0.00067     0.63690   
+     7. BD*(   1) O   1 - H   3          0.00067     0.63690   
+       -------------------------------
+              Total Lewis    9.99866  ( 99.9866%)
+        Valence non-Lewis    0.00134  (  0.0134%)
+        Rydberg non-Lewis    0.00000  (  0.0000%)
+       -------------------------------
+            Total unit  1   10.00000  (100.0000%)
+           Charge unit  1    0.00000
+ B after Tr=     0.028073    0.000000    0.021155
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Final structure in terms of initial Z-matrix:
+ O
+ H,1,R1
+ H,1,R1,2,A1
+      Variables:
+ R1=0.98928367
+ A1=100.03667488
+ 1\1\GINC-OSMIUM\FOpt\RHF\STO-3G\H2O1\ERIC\06-May-2025\0\\# hf/sto-3g o
+ pt freq pop=nbo\\Water\\0,1\O,-0.0212223216,0.,-0.0159921664\H,0.03023
+ 65978,0.,0.9719522486\H,0.9426348028,0.,-0.2388410645\\Version=ES64L-G
+ 16RevA.03\State=1-A1\HF=-74.9659012\RMSD=5.458e-12\RMSF=9.684e-05\Dipo
+ le=0.5370839,0.,0.4047218\Quadrupole=0.2145107,-0.6028113,0.3883006,0.
+ ,-0.3030386,0.\PG=C02V [C2(O1),SGV(H2)]\\@
+
+
+ ON INDUCTION, OR "WHY DO YOU BELIEVE THE SUN WILL RISE TOMORROW?":
+
+ ... THE FARMER WHO HAS FED THE CHICKEN EVERY DAY THROUGHOUT ITS
+ LIFE AT LAST WRINGS ITS NECK INSTEAD, SHOWING THAT MORE REFINED VIEWS
+ AS TO THE UNIFORMITY OF NATURE WOULD HAVE BEEN USEFUL TO THE CHICKEN.
+
+                               -- BERTRAND RUSSELL
+ Job cpu time:       0 days  0 hours  0 minutes  3.7 seconds.
+ Elapsed time:       0 days  0 hours  0 minutes  3.1 seconds.
+ File lengths (MBytes):  RWF=      6 Int=      0 D2E=      0 Chk=      1 Scr=      1
+ Normal termination of Gaussian 16 at Tue May  6 22:05:38 2025.
+ Link1:  Proceeding to internal job step number  2.
+ ---------------------------------------------------------------
+ #N Geom=AllCheck Guess=TCheck SCRF=Check GenChk RHF/STO-3G Freq
+ ---------------------------------------------------------------
+ 1/10=4,29=7,30=1,38=1,40=1/1,3;
+ 2/12=2,40=1/2;
+ 3/6=3,11=1,14=-4,25=1,30=1,70=2,71=2,116=1,140=1/1,2,3;
+ 4/5=101/1;
+ 5/5=2,38=6,98=1/2;
+ 8/6=4,10=90,11=11/1;
+ 10/13=10,15=4/2;
+ 11/6=3,8=1,9=11,15=111,16=1/1,2,10;
+ 10/6=1/2;
+ 6/7=2,8=2,9=2,10=2,28=1,40=1/1,7;
+ 7/8=1,10=1,25=1/1,2,3,16;
+ 1/10=4,30=1/3;
+ 99//99;
+ Structure from the checkpoint file:  "water_neutral_nbo_opt_freq.chk"
+ -----
+ Water
+ -----
+ Charge =  0 Multiplicity = 1
+ Redundant internal coordinates found in file.  (old form).
+ O,0,-0.0212223216,0.,-0.0159921664
+ H,0,0.0302365978,0.,0.9719522486
+ H,0,0.9426348028,0.,-0.2388410645
+ Recover connectivity data from disk.
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+                           ----------------------------
+                           !    Initial Parameters    !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9893         calculate D2E/DX2 analytically  !
+ ! R2    R(1,3)                  0.9893         calculate D2E/DX2 analytically  !
+ ! A1    A(2,1,3)              100.0367         calculate D2E/DX2 analytically  !
+ --------------------------------------------------------------------------------
+ Trust Radius=3.00D-01 FncErr=1.00D-07 GrdErr=1.00D-07 EigMax=2.50D+02 EigMin=1.00D-04
+ Number of steps in this run=      2 maximum allowed number of steps=      2.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.021222   -0.000000   -0.015992
+      2          1           0        0.030237   -0.000000    0.971952
+      3          1           0        0.942635    0.000000   -0.238841
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.989284   0.000000
+     3  H    0.989284   1.516077   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000    0.000000    0.127131
+      2          1           0        0.000000    0.758039   -0.508525
+      3          1           0       -0.000000   -0.758039   -0.508525
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         698.7184174         436.3342031         268.5996564
+ Standard basis: STO-3G (5D, 7F)
+ There are     4 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     0 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     2 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are     4 symmetry adapted basis functions of A1  symmetry.
+ There are     0 symmetry adapted basis functions of A2  symmetry.
+ There are     1 symmetry adapted basis functions of B1  symmetry.
+ There are     2 symmetry adapted basis functions of B2  symmetry.
+     7 basis functions,    21 primitive gaussians,     7 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         8.9075952494 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=     7 RedAO= T EigKep=  3.63D-01  NBF=     4     0     1     2
+ NBsUse=     7 1.00D-06 EigRej= -1.00D+00 NBFU=     4     0     1     2
+ Initial guess from the checkpoint file:  "water_neutral_nbo_opt_freq.chk"
+ B after Tr=    -0.000000   -0.000000   -0.000000
+         Rot=    1.000000   -0.000000    0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=803110.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Skip diagonalization as Alpha Fock matrix is already diagonal.
+ SCF Done:  E(RHF) =  -74.9659011806     A.U. after    1 cycles
+            NFock=  1  Conv=0.00D+00     -V/T= 2.0060
+ Range of M.O.s used for correlation:     1     7
+ NBasis=     7 NAE=     5 NBE=     5 NFC=     0 NFV=     0
+ NROrb=      7 NOA=     5 NOB=     5 NVA=     2 NVB=     2
+          Differentiating once with respect to electric field.
+                with respect to dipole field.
+          Electric field/nuclear overlap derivatives assumed to be zero.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=803505.
+          There are     3 degrees of freedom in the 1st order CPHF.  IDoFFX=0 NUNeed=     3.
+      3 vectors produced by pass  0 Test12= 3.33D-16 3.33D-08 XBig12= 8.42D-01 6.90D-01.
+ AX will form     3 AO Fock derivatives at one time.
+      2 vectors produced by pass  1 Test12= 3.33D-16 3.33D-08 XBig12= 8.35D-03 7.20D-02.
+      2 vectors produced by pass  2 Test12= 3.33D-16 3.33D-08 XBig12= 1.07D-04 6.31D-03.
+      2 vectors produced by pass  3 Test12= 3.33D-16 3.33D-08 XBig12= 6.37D-09 7.70D-05.
+ InvSVY:  IOpt=1 It=  1 EMax= 1.11D-16
+ Solved reduced A of dimension     9 with     3 vectors.
+ End of Minotr F.D. properties file   721 does not exist.
+ End of Minotr F.D. properties file   722 does not exist.
+ End of Minotr F.D. properties file   788 does not exist.
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+ G2DrvN: will do     4 centers at a time, making    1 passes.
+ PxScal for G2LodP:  IOpCl= 0 ISclPx=1 IMOff=     1 NMtTot=     4 NTT=      28 ScalPx= 1.10D+00
+ Calling FoFCou, ICntrl=  3107 FMM=F I1Cent=   0 AccDes= 0.00D+00.
+ End of G2Drv F.D. properties file   721 does not exist.
+ End of G2Drv F.D. properties file   722 does not exist.
+ End of G2Drv F.D. properties file   788 does not exist.
+          IDoAtm=111
+          Differentiating once with respect to electric field.
+                with respect to dipole field.
+          Differentiating once with respect to nuclear coordinates.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=803577.
+          There are     9 degrees of freedom in the 1st order CPHF.  IDoFFX=4 NUNeed=     9.
+ Will reuse    3 saved solutions.
+      6 vectors produced by pass  0 Test12= 1.11D-16 1.11D-08 XBig12= 2.68D-02 1.64D-01.
+ AX will form     6 AO Fock derivatives at one time.
+      4 vectors produced by pass  1 Test12= 1.11D-16 1.11D-08 XBig12= 1.34D-04 8.52D-03.
+ InvSVY:  IOpt=1 It=  1 EMax= 2.22D-16
+ Solved reduced A of dimension    10 with     6 vectors.
+ Isotropic polarizability for W=    0.000000        2.70 Bohr**3.
+ End of Minotr F.D. properties file   721 does not exist.
+ End of Minotr F.D. properties file   722 does not exist.
+ End of Minotr F.D. properties file   788 does not exist.
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2)
+ The electronic state is 1-A1.
+ Alpha  occ. eigenvalues --  -20.25155  -1.25760  -0.59393  -0.45972  -0.39262
+ Alpha virt. eigenvalues --    0.58190   0.69284
+          Condensed to atoms (all electrons):
+               1          2          3
+     1  O    7.822822   0.253915   0.253915
+     2  H    0.253915   0.626174  -0.045416
+     3  H    0.253915  -0.045416   0.626174
+ Mulliken charges:
+               1
+     1  O   -0.330652
+     2  H    0.165326
+     3  H    0.165326
+ Sum of Mulliken charges =  -0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  O   -0.000000
+ APT charges:
+               1
+     1  O   -0.169225
+     2  H    0.084612
+     3  H    0.084612
+ Sum of APT charges =  -0.00000
+ APT charges with hydrogens summed into heavy atoms:
+               1
+     1  O   -0.000000
+ Electronic spatial extent (au):  <R**2>=             18.2669
+ Charge=             -0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=             -0.0000    Y=             -0.0000    Z=             -1.7093  Tot=              1.7093
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -6.1255   YY=             -4.4853   ZZ=             -5.3334
+   XY=              0.0000   XZ=              0.0000   YZ=             -0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -0.8108   YY=              0.8294   ZZ=             -0.0186
+   XY=              0.0000   XZ=              0.0000   YZ=             -0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=              0.0000  YYY=             -0.0000  ZZZ=             -0.1746  XYY=             -0.0000
+  XXY=             -0.0000  XXZ=              0.0191  XZZ=              0.0000  YZZ=             -0.0000
+  YYZ=             -0.5315  XYZ=             -0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=             -3.2652 YYYY=             -6.7325 ZZZZ=             -5.2185 XXXY=             -0.0000
+ XXXZ=             -0.0000 YYYX=             -0.0000 YYYZ=              0.0000 ZZZX=             -0.0000
+ ZZZY=             -0.0000 XXYY=             -1.8083 XXZZ=             -1.4595 YYZZ=             -1.7388
+ XXYZ=             -0.0000 YYXZ=              0.0000 ZZXY=             -0.0000
+ N-N= 8.907595249426D+00 E-N=-1.963550185162D+02  KE= 7.451886834874D+01
+ Symmetry A1   KE= 6.651724437958D+01
+ Symmetry A2   KE= 0.000000000000D+00
+ Symmetry B1   KE= 5.057462452019D+00
+ Symmetry B2   KE= 2.944161517138D+00
+  Exact polarizability:   0.040   0.000   5.506   0.000   0.000   2.565
+ Approx polarizability:   0.020   0.000   3.937   0.000  -0.000   2.605
+ ******************************Gaussian NBO Version 3.1******************************
+             N A T U R A L   A T O M I C   O R B I T A L   A N D
+          N A T U R A L   B O N D   O R B I T A L   A N A L Y S I S
+ ******************************Gaussian NBO Version 3.1******************************
+       /RESON  / : Allow strongly delocalized NBO set
+
+ Analyzing the SCF density
+
+ Job title: Water                                                           
+
+ Storage needed:       205 in NPA,       237 in NBO ( 104857537 available)
+
+
+ NATURAL POPULATIONS:  Natural atomic orbital occupancies 
+                                                          
+   NAO  Atom  No  lang   Type(AO)    Occupancy      Energy
+ ----------------------------------------------------------
+     1    O    1  S      Cor( 1S)     2.00000     -20.14560
+     2    O    1  S      Val( 2S)     1.77260      -1.03262
+     3    O    1  px     Val( 2p)     2.00000      -0.39262
+     4    O    1  py     Val( 2p)     1.14704      -0.04515
+     5    O    1  pz     Val( 2p)     1.44634      -0.18846
+ 
+     6    H    2  S      Val( 1S)     0.81700       0.06189
+ 
+     7    H    3  S      Val( 1S)     0.81700       0.06189
+
+
+ Summary of Natural Population Analysis:                  
+                                                          
+                                       Natural Population 
+                Natural  -----------------------------------------------
+    Atom  No    Charge         Core      Valence    Rydberg      Total
+ -----------------------------------------------------------------------
+      O    1   -0.36599      2.00000     6.36599    0.00000     8.36599
+      H    2    0.18300      0.00000     0.81700    0.00000     0.81700
+      H    3    0.18300      0.00000     0.81700    0.00000     0.81700
+ =======================================================================
+   * Total *   -0.00000      2.00000     8.00000    0.00000    10.00000
+
+                                 Natural Population      
+ --------------------------------------------------------
+   Core                       2.00000 (100.0000% of   2)
+   Valence                    8.00000 (100.0000% of   8)
+   Natural Minimal Basis     10.00000 (100.0000% of  10)
+   Natural Rydberg Basis      0.00000 (  0.0000% of  10)
+ --------------------------------------------------------
+
+    Atom  No          Natural Electron Configuration
+ ----------------------------------------------------------------------------
+      O    1      [core]2S( 1.77)2p( 4.59)
+      H    2            1S( 0.82)
+      H    3            1S( 0.82)
+
+
+ NATURAL BOND ORBITAL ANALYSIS:
+
+                       Occupancies       Lewis Structure    Low   High
+           Occ.    -------------------  -----------------   occ   occ
+  Cycle   Thresh.   Lewis   Non-Lewis     CR  BD  3C  LP    (L)   (NL)   Dev
+ =============================================================================
+   1(1)    1.90     9.99866   0.00134      1   2   0   2     0      0    0.00
+ -----------------------------------------------------------------------------
+
+ Structure accepted: No low occupancy Lewis orbitals
+
+ --------------------------------------------------------
+   Core                      2.00000 (100.000% of   2)
+   Valence Lewis             7.99866 ( 99.983% of   8)
+  ==================       ============================
+   Total Lewis               9.99866 ( 99.987% of  10)
+  -----------------------------------------------------
+   Valence non-Lewis         0.00134 (  0.013% of  10)
+   Rydberg non-Lewis         0.00000 (  0.000% of  10)
+  ==================       ============================
+   Total non-Lewis           0.00134 (  0.013% of  10)
+ --------------------------------------------------------
+
+
+       (Occupancy)   Bond orbital/ Coefficients/ Hybrids
+ ---------------------------------------------------------------------------------
+     1. (1.99933) BD ( 1) O   1 - H   2  
+                ( 59.16%)   0.7691* O   1 s( 14.56%)p 5.87( 85.44%)
+                                            0.0000  0.3815  0.0000  0.7071 -0.5953
+                ( 40.84%)   0.6391* H   2 s(100.00%)
+                                            1.0000
+     2. (1.99933) BD ( 1) O   1 - H   3  
+                ( 59.16%)   0.7691* O   1 s( 14.56%)p 5.87( 85.44%)
+                                            0.0000 -0.3815  0.0000  0.7071  0.5953
+                ( 40.84%)   0.6391* H   3 s(100.00%)
+                                           -1.0000
+     3. (2.00000) CR ( 1) O   1           s(100.00%)
+                                            1.0000  0.0000  0.0000  0.0000  0.0000
+     4. (2.00000) LP ( 1) O   1           s( 70.89%)p 0.41( 29.11%)
+                                            0.0000  0.8419  0.0000  0.0000  0.5396
+     5. (2.00000) LP ( 2) O   1           s(  0.00%)p 1.00(100.00%)
+                                            0.0000  0.0000  1.0000  0.0000  0.0000
+     6. (0.00067) BD*( 1) O   1 - H   2  
+                ( 40.84%)   0.6391* O   1 s( 14.56%)p 5.87( 85.44%)
+                                           -0.0000 -0.3815 -0.0000 -0.7071  0.5953
+                ( 59.16%)  -0.7691* H   2 s(100.00%)
+                                           -1.0000
+     7. (0.00067) BD*( 1) O   1 - H   3  
+                ( 40.84%)   0.6391* O   1 s( 14.56%)p 5.87( 85.44%)
+                                           -0.0000  0.3815 -0.0000 -0.7071 -0.5953
+                ( 59.16%)  -0.7691* H   3 s(100.00%)
+                                            1.0000
+
+
+ NHO Directionality and "Bond Bending" (deviations from line of nuclear centers)
+
+         [Thresholds for printing:  angular deviation  >  1.0 degree]
+                                    hybrid p-character > 25.0%
+                                    orbital occupancy  >  0.10e
+
+                                Line of Centers        Hybrid 1              Hybrid 2
+                                ---------------  -------------------   ------------------
+                NBO               Theta   Phi    Theta   Phi    Dev    Theta   Phi    Dev
+ ========================================================================================
+     4. LP (   1) O   1             --     --      0.0    0.0   --       --     --    --
+     5. LP (   2) O   1             --     --     90.0    0.0   --       --     --    --
+
+
+ Second Order Perturbation Theory Analysis of Fock Matrix in NBO Basis
+
+     Threshold for printing:   0.50 kcal/mol
+                                                                              E(2)  E(j)-E(i) F(i,j)
+         Donor NBO (i)                     Acceptor NBO (j)                 kcal/mol   a.u.    a.u. 
+ ===================================================================================================
+
+ within unit  1
+   1. BD (   1) O   1 - H   2        /  7. BD*(   1) O   1 - H   3            0.59    1.41    0.026
+   2. BD (   1) O   1 - H   3        /  6. BD*(   1) O   1 - H   2            0.59    1.41    0.026
+
+
+ Natural Bond Orbitals (Summary):
+
+                                                            Principal Delocalizations
+           NBO                        Occupancy    Energy   (geminal,vicinal,remote)
+ ====================================================================================
+ Molecular unit  1  (H2O)
+     1. BD (   1) O   1 - H   2          1.99933    -0.77653  7(g)
+     2. BD (   1) O   1 - H   3          1.99933    -0.77653  6(g)
+     3. CR (   1) O   1                  2.00000   -20.14560   
+     4. LP (   1) O   1                  2.00000    -0.86319   
+     5. LP (   2) O   1                  2.00000    -0.39262   
+     6. BD*(   1) O   1 - H   2          0.00067     0.63690   
+     7. BD*(   1) O   1 - H   3          0.00067     0.63690   
+       -------------------------------
+              Total Lewis    9.99866  ( 99.9866%)
+        Valence non-Lewis    0.00134  (  0.0134%)
+        Rydberg non-Lewis    0.00000  (  0.0000%)
+       -------------------------------
+            Total unit  1   10.00000  (100.0000%)
+           Charge unit  1    0.00000
+ Calling FoFJK, ICntrl=    100127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ Full mass-weighted force constant matrix:
+ Low frequencies ---  -50.6721  -45.6361  -42.1873    0.0005    0.0018    0.0023
+ Low frequencies --- 2169.7613 4141.3837 4392.5759
+ Diagonal vibrational polarizability:
+        0.0000000       0.0417626       0.1108994
+ Diagonal vibrational hyperpolarizability:
+        0.0000000       0.0000000      -0.4935891
+ Harmonic frequencies (cm**-1), IR intensities (KM/Mole), Raman scattering
+ activities (A**4/AMU), depolarization ratios for plane and unpolarized
+ incident light, reduced masses (AMU), force constants (mDyne/A),
+ and normal coordinates:
+                      1                      2                      3
+                     A1                     A1                     B2
+ Frequencies --   2169.7613              4141.3837              4392.5759
+ Red. masses --      1.0785                 1.0491                 1.0774
+ Frc consts  --      2.9915                10.6012                12.2477
+ IR Inten    --      7.2483                44.2724                29.9428
+ Raman Activ --      9.2632                47.7989                21.5409
+ Depolar (P) --      0.7246                 0.1791                 0.7500
+ Depolar (U) --      0.8403                 0.3038                 0.8571
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   8    -0.00  -0.00  -0.07     0.00  -0.00   0.05    -0.00  -0.07  -0.00
+     2   1     0.00   0.45   0.54     0.00   0.57  -0.42    -0.00   0.54  -0.45
+     3   1     0.00  -0.45   0.54    -0.00  -0.57  -0.42     0.00   0.54   0.45
+
+ -------------------
+ - Thermochemistry -
+ -------------------
+ Temperature   298.150 Kelvin.  Pressure   1.00000 Atm.
+ Atom     1 has atomic number  8 and mass  15.99491
+ Atom     2 has atomic number  1 and mass   1.00783
+ Atom     3 has atomic number  1 and mass   1.00783
+ Molecular mass:    18.01056 amu.
+ Principal axes and moments of inertia in atomic units:
+                           1         2         3
+     Eigenvalues --     2.58293   4.13614   6.71907
+           X            0.00000   0.00000   1.00000
+           Y            1.00000   0.00000  -0.00000
+           Z           -0.00000   1.00000   0.00000
+ This molecule is an asymmetric top.
+ Rotational symmetry number  2.
+ Rotational temperatures (Kelvin)     33.53320    20.94074    12.89075
+ Rotational constants (GHZ):         698.71842   436.33420   268.59966
+ Zero-point vibrational energy      64022.5 (Joules/Mol)
+                                   15.30174 (Kcal/Mol)
+ Vibrational temperatures:   3121.80  5958.53  6319.94
+          (Kelvin)
+ 
+ Zero-point correction=                           0.024385 (Hartree/Particle)
+ Thermal correction to Energy=                    0.027218
+ Thermal correction to Enthalpy=                  0.028162
+ Thermal correction to Gibbs Free Energy=         0.006648
+ Sum of electronic and zero-point Energies=            -74.941516
+ Sum of electronic and thermal Energies=               -74.938683
+ Sum of electronic and thermal Enthalpies=             -74.937739
+ Sum of electronic and thermal Free Energies=          -74.959254
+ 
+                     E (Thermal)             CV                S
+                      KCal/Mol        Cal/Mol-Kelvin    Cal/Mol-Kelvin
+ Total                   17.079              5.968             45.281
+ Electronic               0.000              0.000              0.000
+ Translational            0.889              2.981             34.608
+ Rotational               0.889              2.981             10.672
+ Vibrational             15.302              0.006              0.001
+                       Q            Log10(Q)             Ln(Q)
+ Total Bot       0.875649D-03         -3.057670         -7.040546
+ Total V=0       0.144073D+09          8.158582         18.785829
+ Vib (Bot)       0.607800D-11        -11.216240        -25.826346
+ Vib (V=0)       0.100003D+01          0.000012          0.000028
+ Electronic      0.100000D+01          0.000000          0.000000
+ Translational   0.300431D+07          6.477745         14.915559
+ Rotational      0.479540D+02          1.680825          3.870242
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.000166866    0.000000000   -0.000125743
+      2        1           0.000024915   -0.000000000    0.000140528
+      3        1           0.000141952   -0.000000000   -0.000014785
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000166866 RMS     0.000096835
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Internal  Forces:  Max     0.000141634 RMS     0.000117188
+ Search for a local minimum.
+ Step number   1 out of a maximum of    2
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- analytic derivatives used.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.65453
+           R2          -0.03066   0.65453
+           A1           0.03771   0.03771   0.29686
+ ITU=  0
+     Eigenvalues ---    0.28838   0.63235   0.68520
+ Angle between quadratic step and forces=  17.68 degrees.
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00014485 RMS(Int)=  0.00000001
+ Iteration  2 RMS(Cart)=  0.00000002 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 3.14D-16 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.86948   0.00014   0.00000   0.00024   0.00024   1.86971
+    R2        1.86948   0.00014   0.00000   0.00024   0.00024   1.86971
+    A1        1.74597  -0.00003   0.00000  -0.00017  -0.00017   1.74580
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000142     0.000450     YES
+ RMS     Force            0.000117     0.000300     YES
+ Maximum Displacement     0.000146     0.001800     YES
+ RMS     Displacement     0.000145     0.001200     YES
+ Predicted change in Energy=-3.642617D-08
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9893         -DE/DX =    0.0001              !
+ ! R2    R(1,3)                  0.9893         -DE/DX =    0.0001              !
+ ! A1    A(2,1,3)              100.0367         -DE/DX =    0.0                 !
+ --------------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+
+ ----------------------------------------------------------------------
+
+ Electric dipole moment (input orientation):
+ (Debye = 10**-18 statcoulomb cm , SI units = C m)
+                  (au)            (Debye)         (10**-30 SI)
+   Tot        0.672502D+00      0.170933D+01      0.570171D+01
+   x          0.537084D+00      0.136513D+01      0.455359D+01
+   y          0.000000D+00      0.000000D+00      0.000000D+00
+   z          0.404722D+00      0.102870D+01      0.343137D+01
+
+ Dipole polarizability, Alpha (input orientation).
+ (esu units = cm**3 , SI units = C**2 m**2 J**-1)
+ Alpha(0;0):
+               (au)            (10**-24 esu)      (10**-40 SI)
+   iso        0.270370D+01      0.400647D+00      0.445779D+00
+   aniso      0.473866D+01      0.702197D+00      0.781300D+00
+   xx         0.363006D+01      0.537919D+00      0.598516D+00
+   yx         0.000000D+00      0.000000D+00      0.000000D+00
+   yy         0.400608D-01      0.593640D-02      0.660514D-02
+   zx        -0.141399D+01     -0.209532D+00     -0.233135D+00
+   zy         0.000000D+00      0.000000D+00      0.000000D+00
+   zz         0.444097D+01      0.658084D+00      0.732217D+00
+
+ First dipole hyperpolarizability, Beta (input orientation).
+ ||, _|_  parallel and perpendicular components, (z) with respect to z axis,
+ vector components x,y,z.  Values do not include the 1/n! factor of 1/2.
+ (esu units = statvolt**-1 cm**4 , SI units = C**3 m**3 J**-2)
+ Beta(0;0,0):
+               (au)            (10**-30 esu)      (10**-50 SI)
+   || (z)     0.398853D+01      0.344578D-01      0.127887D-01
+   _|_(z)     0.132951D+01      0.114859D-01      0.426289D-02
+   x          0.264648D+02      0.228635D+00      0.848556D-01
+   y          0.000000D+00      0.000000D+00      0.000000D+00
+   z          0.199426D+02      0.172289D+00      0.639433D-01
+   ||         0.662750D+01      0.572564D-01      0.212501D-01
+   xxx        0.817754D+01      0.706476D-01      0.262201D-01
+   xxy        0.000000D+00      0.000000D+00      0.000000D+00
+   yxy       -0.608397D-01     -0.525608D-03     -0.195074D-03
+   yyy        0.000000D+00      0.000000D+00      0.000000D+00
+   xxz       -0.227523D+01     -0.196562D-01     -0.729519D-02
+   yxz        0.000000D+00      0.000000D+00      0.000000D+00
+   yyz       -0.458460D-01     -0.396074D-03     -0.146999D-03
+   zxz        0.704892D+00      0.608972D-02      0.226014D-02
+   zyz        0.000000D+00      0.000000D+00      0.000000D+00
+   zzz        0.896862D+01      0.774819D-01      0.287566D-01
+
+ ----------------------------------------------------------------------
+
+ Dipole orientation:
+     8         -0.00000000         -0.00000000         -0.05021612
+     1         -1.43248561         -0.00000000          1.15100098
+     1          1.43248561          0.00000000          1.15100098
+
+ Electric dipole moment (dipole orientation):
+ (Debye = 10**-18 statcoulomb cm , SI units = C m)
+                  (au)            (Debye)         (10**-30 SI)
+   Tot        0.672502D+00      0.170933D+01      0.570171D+01
+   x          0.000000D+00      0.000000D+00      0.000000D+00
+   y          0.000000D+00      0.000000D+00      0.000000D+00
+   z          0.672502D+00      0.170933D+01      0.570171D+01
+
+ Dipole polarizability, Alpha (dipole orientation).
+ (esu units = cm**3 , SI units = C**2 m**2 J**-1)
+ Alpha(0;0):
+               (au)            (10**-24 esu)      (10**-40 SI)
+   iso        0.270370D+01      0.400647D+00      0.445779D+00
+   aniso      0.473866D+01      0.702197D+00      0.781300D+00
+   xx         0.550649D+01      0.815977D+00      0.907897D+00
+   yx         0.000000D+00      0.000000D+00      0.000000D+00
+   yy         0.400608D-01      0.593640D-02      0.660514D-02
+   zx         0.000000D+00      0.000000D+00      0.000000D+00
+   zy         0.000000D+00      0.000000D+00      0.000000D+00
+   zz         0.256454D+01      0.380026D+00      0.422836D+00
+
+ First dipole hyperpolarizability, Beta (dipole orientation).
+ ||, _|_  parallel and perpendicular components, (z) with respect to z axis,
+ vector components x,y,z.  Values do not include the 1/n! factor of 1/2.
+ (esu units = statvolt**-1 cm**4 , SI units = C**3 m**3 J**-2)
+ Beta(0;0,0):
+               (au)            (10**-30 esu)      (10**-50 SI)
+   || (z)     0.662750D+01      0.572564D-01      0.212501D-01
+   _|_(z)     0.220917D+01      0.190855D-01      0.708338D-02
+   x          0.000000D+00      0.000000D+00      0.000000D+00
+   y          0.000000D+00      0.000000D+00      0.000000D+00
+   z          0.331375D+02      0.286282D+00      0.106251D+00
+   ||         0.662750D+01      0.572564D-01      0.212501D-01
+   xxx        0.000000D+00      0.000000D+00      0.000000D+00
+   xxy        0.000000D+00      0.000000D+00      0.000000D+00
+   yxy        0.000000D+00      0.000000D+00      0.000000D+00
+   yyy        0.000000D+00      0.000000D+00      0.000000D+00
+   xxz        0.701000D+01      0.605609D-01      0.224766D-01
+   yxz        0.000000D+00      0.000000D+00      0.000000D+00
+   yyz       -0.761796D-01     -0.658132D-03     -0.244259D-03
+   zxz        0.000000D+00      0.000000D+00      0.000000D+00
+   zyz        0.000000D+00      0.000000D+00      0.000000D+00
+   zzz        0.411201D+01      0.355246D-01      0.131846D-01
+
+ ----------------------------------------------------------------------
+ 1\1\GINC-OSMIUM\Freq\RHF\STO-3G\H2O1\ERIC\06-May-2025\0\\#N Geom=AllCh
+ eck Guess=TCheck SCRF=Check GenChk RHF/STO-3G Freq\\Water\\0,1\O,-0.02
+ 12223216,0.,-0.0159921664\H,0.0302365978,0.,0.9719522486\H,0.942634802
+ 8,0.,-0.2388410645\\Version=ES64L-G16RevA.03\State=1-A1\HF=-74.9659012
+ \RMSD=0.000e+00\RMSF=9.684e-05\ZeroPoint=0.0243849\Thermal=0.0272177\D
+ ipole=0.5370839,0.,0.4047218\DipoleDeriv=0.0418916,0.,0.0551128,0.,-0.
+ 5598504,0.,0.0551128,0.,0.0102849,0.1610714,0.,-0.1120286,0.,0.2799252
+ ,0.,-0.0474694,0.,-0.1871596,-0.2029629,0.,0.0569158,0.,0.2799252,0.,-
+ 0.0076435,0.,0.1768747\Polar=3.6300596,0.,0.0400608,-1.4139895,0.,4.44
+ 09695\PolarDeriv=-5.0397825,0.,0.0145182,-0.1901021,0.,-1.355738,0.,-1
+ .6784146,0.,0.,-1.2647761,0.,-0.3612162,0.,0.0109403,-1.128662,0.,-4.4
+ 581542,-0.23572,0.,-0.0260822,1.8091802,0.,0.6346455,0.,-0.3090686,0.,
+ 0.,2.1562017,0.,0.2851572,0.,0.0195089,-0.691798,0.,5.8387072,5.275502
+ 6,0.,0.0115639,-1.6190781,0.,0.7210925,0.,1.9874832,0.,0.,-0.8914255,0
+ .,0.076059,0.,-0.0304492,1.8204601,0.,-1.380553\HyperPolar=8.177537,0.
+ ,-0.0608397,0.,-2.275225,0.,-0.045846,0.7048923,0.,8.9686156\Quadrupol
+ e=0.2145107,-0.6028113,0.3883006,0.,-0.3030386,0.\PG=C02V [C2(O1),SGV(
+ H2)]\NImag=0\\0.69646449,0.,-0.00017394,-0.08143428,0.,0.74316630,-0.0
+ 8200031,0.,-0.09605731,0.08431130,0.,0.00008697,0.,0.,-0.00007742,0.02
+ 481003,0.,-0.63781509,0.00953672,0.,0.65508669,-0.61446418,0.,0.177491
+ 59,-0.00231099,0.,-0.03434675,0.61677517,0.,0.00008697,0.,0.,-0.000009
+ 55,0.,0.,-0.00007742,0.05662424,0.,-0.10535121,0.08652060,0.,-0.017271
+ 60,-0.14314484,0.,0.12262281\\0.00016687,0.,0.00012574,-0.00002491,0.,
+ -0.00014053,-0.00014195,0.,0.00001479\\\@
+
+
+
+ WE LOSE BECAUSE WE WIN
+
+ GAMBLERS,
+
+ RECOLLECTING WHICH,
+
+ TOSS THEIR DICE AGAIN....
+
+
+                          EMILY DICKINSON  BOLTS OF MELODY NO. 533
+ Job cpu time:       0 days  0 hours  0 minutes  1.7 seconds.
+ Elapsed time:       0 days  0 hours  0 minutes  1.4 seconds.
+ File lengths (MBytes):  RWF=      6 Int=      0 D2E=      0 Chk=      1 Scr=      1
+ Normal termination of Gaussian 16 at Tue May  6 22:05:40 2025.


### PR DESCRIPTION
**Found by testing against a real Gaussian 16 calculation** from cclib's own public regression-test data ([cclib/cclib-data](https://github.com/cclib/cclib-data)) — same approach as the ORCA and Turbomole fixes.

## The bug

One real Gaussian 16 file (`mp2_avdz_freq_tight.log`, an MP2/aug-cc-pVDZ frequency job) crashes cclib 1.8.1's own Gaussian parser — its "Leave Link" timing line format (`MaxMem=... cpu: ... elap: ...`) isn't one cclib 1.8.1 handles, and it raises an unhandled internal exception. This is a genuine cclib limitation, not something in this repo — but `read_cclib` let that raw exception escape uncontrolled, unlike every *other* failure mode in the module (missing dependency, unparseable file, no frequencies), which all raise a clean `TSValueError`.

## The fix

Wrap `cclib.io.ccread(...)` in a try/except and re-raise as `TSValueError` with the original exception's type and message. Any cclib parser limitation — this one, or a future one on any supported program — now surfaces consistently instead of leaking an arbitrary internal exception type.

## Also included

- A real, successfully-parsed Gaussian 16 water opt+freq job (`water_neutral_opt_freq.out`) as a genuine-data test fixture — parallel real-data coverage to the ORCA/Turbomole fixtures already in the repo, closing the loop on the original "Gaussian, Turbomole, ORCA" ask.
- Fixed the repo's blanket `*.log` `.gitignore` rule (a leftover from a stock Django template) that was silently excluding real QM logfile fixtures under `tests/data/` — added a scoped negation.

## Verification

Ran both real files through the actual code:
```
water_neutral_opt_freq.out -> electronic_energy(): -74.96589788571758, entropy: 45.28 cal/(mol*K)
mp2_avdz_freq_tight.log    -> clean TSValueError: "cclib raised Exception while parsing '...': Encountered error when parsing."
```
Tests: exact-value real-data parsing + full `cclib_thermo` pipeline for the working file, the real-crash-file regression test, and a cclib-version-independent mocked test of the wrapping logic itself (so coverage doesn't depend on cclib's bug persisting in future releases). Full suite passes (382 passed, 12 pre-existing skips), 100% patch coverage on `qm.py`.

Closes #111