### PR TITLE
Note the QM readers are tested against real program output

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -155,6 +155,14 @@ the ``pyscf`` extra, ``pip install thermoscreening[pyscf]``):
 The geometry and energy (``mf.e_tot``) come from the mean field; frequencies are
 taken from ``frequencies=`` or derived from ``hessian=`` via ``pyscf.hessian``.
 
+.. note::
+
+   ``orca_thermo`` and ``cclib_thermo`` are tested against genuine program
+   output (real ORCA 6.1.1, Gaussian 16 and Turbomole 7.2 calculations), not
+   just synthetic files, and any file cclib or ``read_orca_hess`` cannot parse
+   raises a ``TSValueError`` rather than an arbitrary exception from the
+   underlying parser.
+
 Temperature scans
 -----------------
 


### PR DESCRIPTION
Small docs-only addition following the ORCA/Gaussian/Turbomole real-software validation work (#108, #110, #112): a brief note in the QM-import usage section stating that `orca_thermo`/`cclib_thermo` are validated against genuine program output, and that unparseable files raise `TSValueError` rather than an arbitrary parser exception.

Verified by building the docs locally and visually checking the rendered note (Furo's styled admonition) in the browser. No code changes.