### PR TITLE
Harden _parse_fukui's table-end detection

### DIFF
--- a/ThermoScreening/calculator/xtb_cli.py
+++ b/ThermoScreening/calculator/xtb_cli.py
@@ -9,6 +9,7 @@ energy, optimised geometry and frequencies are then read back and fed into
 """
 
 import os
+import re
 import shutil
 import subprocess
 
@@ -184,9 +185,14 @@ def _parse_fukui(output):
         tokens = line.split()
         if len(tokens) != 4:
             break
-        label, f_plus, f_minus, f_zero = tokens
-        symbol = label.lstrip("0123456789")
-        rows.append((symbol, float(f_plus), float(f_minus), float(f_zero)))
+        label_match = re.match(r"^(\d+)([A-Za-z]+)$", tokens[0])
+        if label_match is None:
+            break
+        try:
+            f_plus, f_minus, f_zero = (float(token) for token in tokens[1:])
+        except ValueError:
+            break
+        rows.append((label_match.group(2), f_plus, f_minus, f_zero))
     return rows
 
 

--- a/tests/calculator/test_xtb_cli.py
+++ b/tests/calculator/test_xtb_cli.py
@@ -110,6 +110,48 @@ def test_parse_fukui_raises_without_table():
         xtb_cli._parse_fukui("no such table here")
 
 
+def test_parse_fukui_stops_at_coincidental_four_token_line_with_bad_label():
+    # a line right after the table with 4 tokens but a label that isn't
+    # "digits then letters" must not be misparsed as data -- token count
+    # alone isn't enough to detect the end of the table
+    output = (
+        "Fukui functions:\n"
+        "     #        f(+)     f(-)     f(0)\n"
+        "     1C       0.024    0.024    0.024\n"
+        "     abc      0.1      0.2      0.3\n"
+        "     8O       0.131    0.129    0.130\n"
+    )
+    rows = xtb_cli._parse_fukui(output)
+
+    assert rows == [("C", 0.024, 0.024, 0.024)]
+
+
+def test_parse_fukui_stops_at_coincidental_four_token_line_with_bad_values():
+    # a line with a valid-looking label but non-numeric values must also
+    # not be misparsed as data
+    output = (
+        "Fukui functions:\n"
+        "     #        f(+)     f(-)     f(0)\n"
+        "     1C       0.024    0.024    0.024\n"
+        "     2C       n/a      n/a      n/a\n"
+        "     8O       0.131    0.129    0.130\n"
+    )
+    rows = xtb_cli._parse_fukui(output)
+
+    assert rows == [("C", 0.024, 0.024, 0.024)]
+
+
+def test_parse_fukui_handles_multi_digit_index_and_multi_letter_symbol():
+    output = (
+        "Fukui functions:\n"
+        "     #        f(+)     f(-)     f(0)\n"
+        "    14Cl      0.010    0.020    0.015\n"
+    )
+    rows = xtb_cli._parse_fukui(output)
+
+    assert rows == [("Cl", 0.010, 0.020, 0.015)]
+
+
 def test_run_xtb_fukui_builds_command_and_parses(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("XTB_COMMAND", "/fake/xtb")


### PR DESCRIPTION
\`_parse_fukui\` (added in #123) only checked token count (\`len(tokens) != 4\`) to detect the end of the \`Fukui functions:\` table. A code review flagged this as an "acceptable risk" of stdout-scraping, but on a second look it's a cheap fix, not something to just accept.

Verified xtb writes this data \*only\* to stdout: a clean-directory \`--vfukui\` run writes no dedicated file for it, only \`charges\`/\`wbo\`/\`xtbrestart\`/\`xtbtopo.mol\` -- so stdout-scraping itself isn't avoidable. But the end-of-table check can be tightened: a coincidental 4-token line right after the real table (before the blank line that actually ends it) would previously get silently misparsed as a data row.

## The fix

Also verify the label matches "digits then letters" (\`^(\d+)([A-Za-z]+)$\`) and the last 3 tokens parse as floats before accepting a row; either check failing now correctly ends the table instead of raising deep inside a malformed row.

## Verification

Two new regression tests reproduce the exact failure mode this fixes (a coincidental 4-token line with a bad label, and one with non-numeric values), plus a test for multi-digit atom indices with multi-letter element symbols (e.g. \`14Cl\`). Full suite: 421 passed, 10 skipped with a real \`xtb\` binary. New code fully covered (only remaining gap in the file pre-dates this change). Docs build clean.

Closes #124