### PR TITLE
Add Zenodo release metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,23 @@
+{
+    "title": "ThermoScreening",
+    "description": "ThermoScreening is a Python package for calculating and screening molecular thermochemical properties from quantum-chemistry outputs and DFTB+, xTB and PySCF workflows. It provides thermochemistry, conformer ensembles, pKa and redox helpers, transition-state kinetics and batch screening.",
+    "license": "lgpl-2.1-or-later",
+    "upload_type": "software",
+    "creators": [
+        {
+            "name": "Kröll, Stefanie"
+        },
+        {
+            "name": "Gallmetzer, Josef M."
+        }
+    ],
+    "keywords": [
+        "Python",
+        "thermochemistry",
+        "computational chemistry",
+        "molecular screening",
+        "DFTB+",
+        "xTB",
+        "redox chemistry"
+    ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+cff-version: 1.2.0
+message: "If you use ThermoScreening, please cite the archived software release."
+title: "ThermoScreening"
+type: software
+abstract: >-
+  ThermoScreening is a Python package for calculating and screening molecular
+  thermochemical properties from quantum-chemistry outputs and DFTB+, xTB and
+  PySCF workflows.
+authors:
+  - family-names: Kröll
+    given-names: Stefanie
+  - family-names: Gallmetzer
+    given-names: Josef M.
+repository-code: "https://github.com/MolarVerse/ThermoScreening"
+url: "https://molarverse.github.io/ThermoScreening/"
+license: LGPL-2.1-or-later
+keywords:
+  - Python
+  - thermochemistry
+  - computational chemistry
+  - molecular screening
+  - DFTB+
+  - xTB
+  - redox chemistry

--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ python -m pylint ThermoScreening
 
 DFTB+ integration tests run only when the executables are available and `DFTB_PREFIX` points to a valid Slater-Koster directory. Otherwise they are skipped so the pure-Python test suite remains portable.
 
+## Citing
+
+If you use ThermoScreening in research, cite the archived software release.
+Machine-readable citation metadata is available in [`CITATION.cff`](CITATION.cff),
+which also powers GitHub's **Cite this repository** feature. Each GitHub release
+is archived by Zenodo and receives a version-specific DOI.
+
 ## Roadmap
 
 Planned work is tracked in GitHub issues rather than in this README. The tool

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,8 @@
 # Releasing
 
-Releases are published to PyPI automatically when a GitHub Release is created —
-there is no manual upload step and no stored API token.
+Releases are published to PyPI and archived by Zenodo automatically when a
+GitHub Release is created. There is no manual package upload step and no stored
+PyPI API token.
 
 ## Cut a release
 
@@ -20,6 +21,8 @@ there is no manual upload step and no stored API token.
    [`.github/workflows/publish.yml`](.github/workflows/publish.yml), which builds
    the sdist + wheel and uploads them to PyPI via
    [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC).
+4. Verify the release on PyPI and Zenodo. Zenodo should create a version-specific
+   DOI under the project's concept DOI.
 
 ## Versioning
 
@@ -39,6 +42,8 @@ there is no manual upload step and no stored API token.
   (owner `MolarVerse`, repository `ThermoScreening`, workflow `publish.yml`, no
   environment). If a release's publish job fails with `invalid-publisher`, these
   four values on PyPI must match the workflow.
+- The Zenodo GitHub integration must remain enabled for `MolarVerse/ThermoScreening`.
+  Zenodo reads `.zenodo.json` when it archives each release.
 - To publish **conda-forge** as well (the channel that also pulls the DFTB+ /
   xtb / tblite backends), `PQAnalysis` first needs to be available on
   conda-forge; then submit a recipe via `staged-recipes`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "setuptools_scm>=8"]
+requires = ["setuptools>=77", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -14,12 +14,12 @@ authors = [
 description = "A Python package for screening molecules for their thermochemical properties."
 requires-python = ">=3.12"
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "LGPL-2.1-or-later"
+license-files = ["LICENSE"]
 keywords = ["thermochemistry", "DFTB+", "xTB", "screening", "computational chemistry"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
-    "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)",
     "Operating System :: OS Independent",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Chemistry",


### PR DESCRIPTION
## Summary
- Add Zenodo and CFF citation metadata.
- Align package license metadata with the existing LGPL license.
- Document Zenodo verification in the release process.

## Validation
- CFF 1.2 schema validation passed.
- `415 passed, 16 skipped`.
- Package build completed without license warnings.